### PR TITLE
Temp fix for project metadata appearing on editor

### DIFF
--- a/src/components/editor/editor.vue
+++ b/src/components/editor/editor.vue
@@ -128,7 +128,7 @@
                 :sourceCounts="sourceCounts"
             ></slide-editor>
         </div>
-        <slot name="metadataModal"></slot>
+        <!-- <slot name="metadataModal"></slot> -->
         <!-- <confirmation-modal
             :name="`reload-config`"
             :message="$t('editor.refreshChanges.modal')"


### PR DESCRIPTION
### Changes ###
- Commented out code that currently makes it so the project metadata also appears at the bottom of the editor page

From what I've seen, I don't think this is a routing issue. The project metadata screen that appears is from the `Edit Project Metadata` button on the editor, which I think is a modal problem.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/yileifeng/storylines-editor/4)
<!-- Reviewable:end -->
