### PR TITLE
Replace modals for vue 3

### DIFF
--- a/src/components/editor/chart-editor.vue
+++ b/src/components/editor/chart-editor.vue
@@ -37,25 +37,26 @@
                 handle=".handle"
                 @update="onChartsEdited"
                 class="flex flex-wrap list-none"
+                item-key="name"
             >
-                <!-- @delete="$modals.show(`${chart.name}-${index}`)" -->
-                <template #item="{ chart, index }" item-key="name">
+                <template #item="{ element, index }">
                     <ChartPreview
-                        :key="`${chart.name}-${index}`"
-                        :chart="chart"
+                        :key="`${element.name}-${index}`"
+                        :chart="element"
                         :configFileStructure="configFileStructure"
                         @edit="editChart"
+                        @delete="$vfm.open(`${element.name}-${index}`)"
                     ></ChartPreview>
                 </template>
             </draggable>
         </ul>
-        <!-- <confirmation-modal
+        <confirmation-modal
             v-for="(chart, idx) in chartConfigs"
             :key="`${chart.name}-${idx}`"
             :name="`${chart.name}-${idx}`"
             :message="$t('editor.chart.delete.confirm', { name: chart.name })"
             @Ok="deleteChart(chart)"
-        ></confirmation-modal> -->
+        ></confirmation-modal>
     </div>
 </template>
 
@@ -63,7 +64,7 @@
 import { Options, Prop, Vue } from 'vue-property-decorator';
 import { ChartConfig, ChartPanel, ConfigFileStructure, Highchart, SourceCounts } from '@/definitions';
 import ChartPreviewV from '@/components/editor/helpers/chart-preview.vue';
-// import ConfirmationModalV from '@/components/editor/helpers/confirmation-modal.vue';
+import ConfirmationModalV from '@/components/editor/helpers/confirmation-modal.vue';
 import draggable from 'vuedraggable';
 
 @Options({
@@ -71,7 +72,7 @@ import draggable from 'vuedraggable';
         // TODO: fix when storylines plugin updated to Vue 3
         // 'chart-panel': ChartPanelV,
         ChartPreview: ChartPreviewV,
-        // 'confirmation-modal': ConfirmationModalV,
+        'confirmation-modal': ConfirmationModalV,
         draggable
     }
 })

--- a/src/components/editor/editor.vue
+++ b/src/components/editor/editor.vue
@@ -27,9 +27,9 @@
                 <span :class="metadata.title ? 'text-xs' : ''">UUID: {{ uuid }}</span>
             </div>
             <span class="ml-auto"></span>
-            <!-- @click="$modals.show(`reload-config`)" -->
             <button
                 v-if="unsavedChanges"
+                @click="$vfm.open(`reload-config`)"
                 class="border-2 border-red-700 text-red-700 rounded p-1 mr-2"
                 v-tippy="{
                     delay: '200',
@@ -82,8 +82,7 @@
         <div class="flex">
             <div class="w-80 flex-shrink-0 border-r border-black editor-toc">
                 <div class="flex items-center justify-center border-b p-2">
-                    <!-- @click.stop="$modals.show('metadata-edit-modal')" -->
-                    <button>
+                    <button @click.stop="$vfm.open('metadata-edit-modal')">
                         <span class="align-middle inline-block px-1"
                             ><svg
                                 clip-rule="evenodd"
@@ -129,11 +128,11 @@
             ></slide-editor>
         </div>
         <slot name="metadataModal"></slot>
-        <!-- <confirmation-modal
+        <confirmation-modal
             :name="`reload-config`"
             :message="$t('editor.refreshChanges.modal')"
             @Ok="$emit('refresh-config')"
-        /> -->
+        />
     </div>
 </template>
 
@@ -145,12 +144,12 @@ import { VueSpinnerOval } from 'vue3-spinners';
 import SlideEditorV from './slide-editor.vue';
 import SlideTocV from './slide-toc.vue';
 import MetadataContentV from './helpers/metadata-content.vue';
-// import ConfirmationModalV from './helpers/confirmation-modal.vue';
+import ConfirmationModalV from './helpers/confirmation-modal.vue';
 
 @Options({
     components: {
         'metadata-content': MetadataContentV,
-        // 'confirmation-modal': ConfirmationModalV,
+        'confirmation-modal': ConfirmationModalV,
         spinner: VueSpinnerOval,
         'slide-editor': SlideEditorV,
         'slide-toc': SlideTocV

--- a/src/components/editor/helpers/confirmation-modal.vue
+++ b/src/components/editor/helpers/confirmation-modal.vue
@@ -1,28 +1,38 @@
 <template>
-    <vue-modal :name="name" :outer-close="false" :hide-close-btn="true" size="md">
+    <vue-final-modal
+        :modalId="name"
+        class="flex justify-center items-center"
+        content-class="flex flex-col max-w-xl mx-4 p-4 bg-white dark:bg-gray-900 border dark:border-gray-700 rounded-lg space-y-2"
+    >
         <h2 slot="header" class="text-lg font-bold">{{ message }}</h2>
         <div class="w-full flex justify-end">
             <button class="confirm-button hover:bg-gray-800" @click.stop="onOk">{{ $t('editor.confirm') }}</button>
             <button class="cancel-button hover:bg-gray-100" @click.stop="onCancel">{{ $t('editor.cancel') }}</button>
         </div>
-    </vue-modal>
+    </vue-final-modal>
 </template>
 
 <script lang="ts">
-import { Prop, Vue } from 'vue-property-decorator';
+import { Options, Prop, Vue } from 'vue-property-decorator';
+import { VueFinalModal } from 'vue-final-modal';
 
+@Options({
+    components: {
+        'vue-final-modal': VueFinalModal
+    }
+})
 export default class MetadataEditorV extends Vue {
     @Prop() message!: string;
     @Prop() name!: string;
 
     onOk(): void {
         this.$emit('Ok');
-        // this.$modals.hide(this.name);
+        this.$vfm.close(this.name);
     }
 
     onCancel(): void {
         this.$emit('Cancel');
-        // this.$modals.hide(this.name);
+        this.$vfm.close(this.name);
     }
 }
 </script>

--- a/src/components/editor/image-editor.vue
+++ b/src/components/editor/image-editor.vue
@@ -40,17 +40,18 @@
             v-show="!imagePreviewsLoading && imagePreviews.length"
             class="flex flex-wrap list-none border my-4"
             @update="onImagesEdited"
+            item-key="id"
         >
-            <template #item="{ image, index }" item-key="id">
-                <ImagePreview :key="`${image.id}-${index}`" :imageFile="image" @delete="deleteImage">
+            <template #item="{ element, index }">
+                <ImagePreview :key="`${element.id}-${index}`" :imageFile="element" @delete="deleteImage">
                     <div class="flex mt-4 items-center w-full text-left">
                         <label class="text-label">{{ $t('editor.image.altTag') }}:</label>
-                        <input class="w-4/5" type="text" v-model="image.altText" @change="onImagesEdited" />
+                        <input class="w-4/5" type="text" v-model="element.altText" @change="onImagesEdited" />
                     </div>
 
                     <div class="flex mt-4 items-center w-full text-left">
                         <label class="text-label">{{ $t('editor.image.label.caption') }}:</label>
-                        <input class="w-4/5" type="text" v-model="image.caption" @change="onImagesEdited" />
+                        <input class="w-4/5" type="text" v-model="element.caption" @change="onImagesEdited" />
                     </div>
                 </ImagePreview>
             </template>

--- a/src/components/editor/map-editor.vue
+++ b/src/components/editor/map-editor.vue
@@ -10,8 +10,11 @@
             <label class="mt-6">{{ $t('editor.map.timeslider.enable') }}</label>
             <input type="checkbox" @change="saveTimeSlider" v-model="usingTimeSlider" />
             <span class="mx-4"></span>
-            <!-- @click="$modals.show('time-slider-edit-modal')" -->
-            <button v-if="usingTimeSlider" class="bg-black text-white hover:bg-gray-800 mt-3">
+            <button
+                v-if="usingTimeSlider"
+                @click="$vfm.open('time-slider-edit-modal')"
+                class="bg-black text-white hover:bg-gray-800 mt-3"
+            >
                 {{ $t('editor.map.timeslider.edit') }}
             </button>
             <br />
@@ -57,7 +60,11 @@
                 </li>
             </ul>
         </div>
-        <vue-modal name="time-slider-edit-modal" :outer-close="false" :hide-close-btn="true" size="md">
+        <vue-final-modal
+            modalId="time-slider-edit-modal"
+            content-class="flex flex-col max-w-xl mx-4 p-4 bg-white border rounded-lg space-y-2"
+            class="flex justify-center items-center"
+        >
             <h2 slot="header" class="text-lg font-bold">{{ $t('editor.map.timeslider.edit') }}</h2>
             <time-slider-editor
                 :config="timeSliderConf"
@@ -73,20 +80,22 @@
                     Done
                 </button>
             </div>
-        </vue-modal>
+        </vue-final-modal>
     </div>
 </template>
 
 <script lang="ts">
 import { Options, Prop, Vue } from 'vue-property-decorator';
 import { ConfigFileStructure, MapPanel, SourceCounts, TimeSliderConfig } from '@/definitions';
+import { VueFinalModal } from 'vue-final-modal';
 import defaultConfigEn from '../../../public/scripts/ramp-editor/samples/map_en.json';
 import defaultConfigFr from '../../../public/scripts/ramp-editor/samples/map_fr.json';
 import TimeSliderEditorV from './helpers/time-slider-editor.vue';
 
 @Options({
     components: {
-        'time-slider-editor': TimeSliderEditorV
+        'time-slider-editor': TimeSliderEditorV,
+        'vue-final-modal': VueFinalModal
     }
 })
 export default class MapEditorV extends Vue {
@@ -192,9 +201,7 @@ export default class MapEditorV extends Vue {
             this.panel.timeSlider = this.usingTimeSlider ? this.timeSliderConf : undefined;
         }
         this.$emit('slide-edit');
-        // if (this.$modals.isActive('time-slider-edit-modal')) {
-        // this.$modals.hide('time-slider-edit-modal');
-        // }
+        this.$vfm.close('time-slider-edit-modal');
     }
 
     saveEditor(e: MessageEvent): void {

--- a/src/components/editor/slide-editor.vue
+++ b/src/components/editor/slide-editor.vue
@@ -24,12 +24,12 @@
                     </div>
                     <div class="flex mt-3">
                         <span class="mx-2 font-bold">{{ $t('editor.slides.makeFull') }}</span>
-                        <!-- @change.stop="$modals.show(`right-only-${slideIndex}`)" -->
                         <input
                             type="checkbox"
                             class="rounded-none cursor-pointer w-4 h-4"
                             v-model="rightOnly"
                             :disabled="rightOnly && currentSlide.panel[panelIndex].type === 'dynamic'"
+                            @change.stop="$vfm.open(`right-only-${slideIndex}`)"
                         />
                     </div>
                 </div>
@@ -183,10 +183,12 @@
                     <span class="ml-auto flex-grow"></span>
                     <div v-if="panelIndex === 1 || rightOnly" class="flex flex-col mr-8">
                         <label class="text-left text-lg">{{ $t('editor.slides.contentType') }}:</label>
-                        <!-- @input=$modals.show(`change-slide-${slideIndex}`); -->
                         <select
                             ref="typeSelector"
-                            @input="newType = $event.target.value"
+                            @input="
+                                $vfm.open(`change-slide-${slideIndex}`);
+                                newType = $event.target.value;
+                            "
                             :value="currentSlide.panel[panelIndex].type"
                         >
                             <option
@@ -216,7 +218,7 @@
         <div v-else class="flex h-full mt-4 justify-center text-gray-600 text-xl">
             <span>{{ $t('editor.slides.select') }}</span>
         </div>
-        <!-- <confirmation-modal
+        <confirmation-modal
             :name="`change-slide-${slideIndex}`"
             :message="$t('editor.slides.changeSlide.confirm', { title: currentSlide.title })"
             @Ok="changePanelType(currentSlide.panel[panelIndex].type, newType)"
@@ -227,7 +229,7 @@
             :message="$t('editor.slides.changeSlide.confirm', { title: currentSlide.title })"
             @Ok="toggleRightOnly()"
             @Cancel="rightOnly = !rightOnly"
-        /> -->
+        />
     </div>
 </template>
 
@@ -257,7 +259,7 @@ import TextEditorV from './text-editor.vue';
 import MapEditorV from './map-editor.vue';
 import LoadingPageV from './helpers/loading-page.vue';
 import DynamicEditorV from './dynamic-editor.vue';
-// import ConfirmationModalV from './helpers/confirmation-modal.vue';
+import ConfirmationModalV from './helpers/confirmation-modal.vue';
 
 @Options({
     components: {
@@ -266,8 +268,8 @@ import DynamicEditorV from './dynamic-editor.vue';
         'text-editor': TextEditorV,
         'map-editor': MapEditorV,
         'loading-page': LoadingPageV,
-        'dynamic-editor': DynamicEditorV
-        // 'confirmation-modal': ConfirmationModalV
+        'dynamic-editor': DynamicEditorV,
+        'confirmation-modal': ConfirmationModalV
     }
 })
 export default class SlideEditorV extends Vue {

--- a/src/components/editor/slide-toc.vue
+++ b/src/components/editor/slide-toc.vue
@@ -12,8 +12,8 @@
                 </span>
                 <span class="align-middle inline-block">{{ $t('editor.slides.addSlide') }}</span>
             </button>
-            <!-- @click.stop="$modals.show(`copy-from-other-lang`)" -->
             <button
+                @click.stop="$vfm.open(`copy-from-other-lang`)"
                 v-tippy="{
                     delay: '200',
                     placement: 'right',
@@ -27,7 +27,11 @@
                     />
                 </svg>
             </button>
-            <!-- <vue-modal :name="`copy-from-other-lang`">
+            <vue-final-modal
+                modalId="copy-from-other-lang"
+                content-class="flex flex-col max-w-xl mx-4 p-4 bg-white border rounded-lg space-y-2"
+                class="flex justify-center items-center"
+            >
                 <h2 slot="header" class="text-xl font-bold">{{ $t('editor.slides.copyFromLang') }}</h2>
                 <div class="flex flex-col">
                     <button
@@ -60,11 +64,11 @@
                         </button>
                     </div>
                 </div>
-            </vue-modal> -->
+            </vue-final-modal>
         </div>
         <ul>
-            <draggable v-model="slides" @update="$emit('slides-updated', slides)">
-                <template #item="{ element, index }" item-key="title">
+            <draggable v-model="slides" @update="$emit('slides-updated', slides)" item-key="title">
+                <template #item="{ element, index }">
                     <li
                         class="toc-slide border-t flex px-2 cursor-pointer hover:bg-gray-100"
                         :class="currentSlide === element ? 'bg-gray-100' : ''"
@@ -83,7 +87,7 @@
                         </div>
                         <div class="flex">
                             <div class="flex flex-col">
-                                <button @click.stop="$modals.show(`delete-slide-${index}`)">
+                                <button @click.stop="$vfm.open(`delete-slide-${index}`)">
                                     <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24">
                                         <path
                                             d="M3 6l3 18h12l3-18h-18zm19-4v2h-20v-2h5.711c.9 0 1.631-1.099 1.631-2h5.316c0 .901.73 2 1.631 2h5.711z"
@@ -120,11 +124,11 @@
                                 </button>
                             </div>
                         </div>
-                        <!-- <confirmation-modal
+                        <confirmation-modal
                             :name="`delete-slide-${index}`"
                             :message="$t('editor.slides.deleteSlide.confirm', { title: element.title })"
                             @Ok="removeSlide(index)"
-                        /> -->
+                        />
                     </li>
                 </template>
             </draggable>
@@ -148,16 +152,18 @@ import {
     SourceCounts,
     TextPanel
 } from '@/definitions';
+import { VueFinalModal } from 'vue-final-modal';
 import cloneDeep from 'clone-deep';
 import draggable from 'vuedraggable';
 
 import SlideEditorV from './slide-editor.vue';
-// import ConfirmationModalV from './helpers/confirmation-modal.vue';
+import ConfirmationModalV from './helpers/confirmation-modal.vue';
 
 @Options({
     components: {
         'slide-editor': SlideEditorV,
-        // 'confirmation-modal': ConfirmationModalV,
+        'confirmation-modal': ConfirmationModalV,
+        'vue-final-modal': VueFinalModal,
         draggable
     }
 })

--- a/src/main.ts
+++ b/src/main.ts
@@ -20,6 +20,7 @@ VueMarkdownEditor.use(githubTheme, {
 
 import { createVfm } from 'vue-final-modal';
 const vfm = createVfm();
+import 'vue-final-modal/dist/style.css';
 
 import VueTippy from 'vue-tippy';
 import 'tippy.js/dist/tippy.css';


### PR DESCRIPTION
Replaced modals for Vue 3 with `vue-final-modal`. All styling should be fairly similar to before. After merge, all the main editor functionality such as deleting slides, deleting charts, resetting changes back to saved state, opening metadata modal inside the editor should all work. The metadata view at the bottom of the editor should also be removed (from #4).

There is one bug I found where after you reset changes in the main editor, it will take you back to the metadata view. To replicate, make any change on the editor page and hit reset changes which should stay on the editor page and re-load the product from the server.  

![image](https://github.com/yileifeng/storylines-editor/assets/31557789/bb88f69c-24f0-4d10-8881-884a580e6c1b)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/yileifeng/storylines-editor/5)
<!-- Reviewable:end -->
