### PR TITLE
Fix bug when going to the editor for a new storylines product

### DIFF
--- a/src/components/editor/metadata-editor.vue
+++ b/src/components/editor/metadata-editor.vue
@@ -189,18 +189,6 @@ import EditorV from './editor.vue';
 
 import cloneDeep from 'clone-deep';
 
-interface RouteParams {
-    uid: string;
-    configLang: string;
-    configs: {
-        [key: string]: StoryRampConfig | undefined;
-    };
-    configFileStructure: ConfigFileStructure;
-    metadata: MetadataContent;
-    slides: Slide[];
-    sourceCounts: SourceCounts;
-}
-
 @Options({
     components: {
         Editor: EditorV,
@@ -272,19 +260,15 @@ export default class MetadataEditorV extends Vue {
         // Find which view to render based on route
         if (this.$route.name === 'editor') {
             this.loadEditor = true;
+            const props = window.history.state.props;
 
             // Properties already passed in props, load editor view (could use a refactor to clean up this workflow process)
-            if (this.$route.params.configs && this.$route.params.configFileStructure) {
-                // declare props typing to get around TS warnings
-                const route = this.$route as RouteLocationNormalized & {
-                    params: RouteParams;
-                };
-
-                this.configs = route.params.configs;
-                this.configFileStructure = route.params.configFileStructure;
-                this.metadata = route.params.metadata;
-                this.slides = route.params.slides;
-                this.sourceCounts = route.params.sourceCounts;
+            if (JSON.parse(props.configs) && JSON.parse(props.configFileStructure)) {
+                this.configs = JSON.parse(props.configs);
+                this.configFileStructure = JSON.parse(props.configFileStructure);
+                this.metadata = JSON.parse(props.metadata);
+                this.slides = JSON.parse(props.slides);
+                this.sourceCounts = JSON.parse(props.sourceCounts);
 
                 // Load product logo (if provided).
                 const logo = this.configs[this.configLang]?.introSlide.logo?.src;
@@ -784,16 +768,15 @@ export default class MetadataEditorV extends Vue {
     updateEditorPath(): void {
         if (this.$route.name !== 'editor') {
             const props = {
-                uid: this.uuid,
                 configLang: this.configLang,
-                configs: this.configs,
-                configFileStructure: this.configFileStructure,
-                sourceCounts: this.sourceCounts,
-                metadata: this.metadata,
-                slides: this.slides
+                configs: JSON.stringify(this.configs),
+                configFileStructure: JSON.stringify(this.configFileStructure),
+                sourceCounts: JSON.stringify(this.sourceCounts),
+                metadata: JSON.stringify(this.metadata),
+                slides: JSON.stringify(this.slides)
             } as unknown as RouteParamsRaw;
 
-            this.$router.push({ name: 'editor', params: props });
+            this.$router.push({ name: 'editor', params: { uid: this.uuid }, state: { props } });
         }
     }
 


### PR DESCRIPTION
Fixed a bug where when creating a new storylines product and clicking `Next` on the `editor-metadata` page, you would end up requesting the product from the server even though there's nothing in the server for it since its new and get the `Failed to load product, no response from server` error

### Notes ###
This happened due to ugprading vue-router and introducing these changes mentioned [here](https://github.com/vuejs/router/blob/main/packages/router/CHANGELOG.md#414-2022-08-22). Because we were passing params not defined in the path in the `updateEditorPath()` method, vue-router now discards them.

When checking if these values were defined in the `created()` method and when the route name was `editor`, it would end up false since they were discarded, and we would end up calling `generateRemoteConfig()` down below in the `created()` method.

Note that we could define the params in the path, but that would be an extremely long path. Instead of trying to pass the props through the `params` option, I used the history state solution mentioned in the link.

### Changes ###
- `updateEditorPath()` now passes the props to the history state instead of `params`
- Should fix the related console warning `Discarded invalid param(s) "configLang", "configs"....`


Not sure if this is the best way to solve this. Will work on fixing the `Reset Changes` issue and maybe come up with a better solution along the way.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/yileifeng/storylines-editor/6)
<!-- Reviewable:end -->
