### PR TITLE
Fix reset changes bug

### DIFF
--- a/src/components/editor/chart-editor.vue
+++ b/src/components/editor/chart-editor.vue
@@ -55,7 +55,7 @@
             :key="`${chart.name}-${idx}`"
             :name="`${chart.name}-${idx}`"
             :message="$t('editor.chart.delete.confirm', { name: chart.name })"
-            @Ok="deleteChart(chart)"
+            @ok="deleteChart(chart)"
         ></confirmation-modal>
     </div>
 </template>

--- a/src/components/editor/editor.vue
+++ b/src/components/editor/editor.vue
@@ -131,7 +131,7 @@
         <confirmation-modal
             :name="`reload-config`"
             :message="$t('editor.refreshChanges.modal')"
-            @Ok="$emit('refresh-config')"
+            @ok="$emit('refresh-config')"
         />
     </div>
 </template>

--- a/src/components/editor/helpers/confirmation-modal.vue
+++ b/src/components/editor/helpers/confirmation-modal.vue
@@ -26,7 +26,7 @@ export default class MetadataEditorV extends Vue {
     @Prop() name!: string;
 
     onOk(): void {
-        this.$emit('Ok');
+        this.$emit('ok');
         this.$vfm.close(this.name);
     }
 

--- a/src/components/editor/slide-editor.vue
+++ b/src/components/editor/slide-editor.vue
@@ -221,13 +221,13 @@
         <confirmation-modal
             :name="`change-slide-${slideIndex}`"
             :message="$t('editor.slides.changeSlide.confirm', { title: currentSlide.title })"
-            @Ok="changePanelType(currentSlide.panel[panelIndex].type, newType)"
+            @ok="changePanelType(currentSlide.panel[panelIndex].type, newType)"
             @Cancel="cancelTypeChange"
         />
         <confirmation-modal
             :name="`right-only-${slideIndex}`"
             :message="$t('editor.slides.changeSlide.confirm', { title: currentSlide.title })"
-            @Ok="toggleRightOnly()"
+            @ok="toggleRightOnly()"
             @Cancel="rightOnly = !rightOnly"
         />
     </div>

--- a/src/components/editor/slide-toc.vue
+++ b/src/components/editor/slide-toc.vue
@@ -127,7 +127,7 @@
                         <confirmation-modal
                             :name="`delete-slide-${index}`"
                             :message="$t('editor.slides.deleteSlide.confirm', { title: element.title })"
-                            @Ok="removeSlide(index)"
+                            @ok="removeSlide(index)"
                         />
                     </li>
                 </template>


### PR DESCRIPTION
This PR fixes the bug where resetting changes in the editor would cause you to go back to the metadata page.
I wans't sure what the expected behaviour should be as this bug seems to have existed before the Vue3 refactor (based on previous PR demo links), so treat this PR as a proof of concept for now (no merge please).

### Changes ###
- Resetting changes in the editor will now keep you on the editor page and reload the previous saved copy of the product
    - If there is no recently saved copy, a new config will be generated
- Fixed console complaining about capitalization of 'Ok' and 'ok' (didn't cause any breaking issues before)
- Fixed bug where trying to access the `.../editor-main/[UID]` page straight away didn't work

Feel free to test it out and see if everything works as expected. If everything looks good and were ok with the changes, can decide to merge.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/yileifeng/storylines-editor/8)
<!-- Reviewable:end -->
