### PR TITLE
Integrate Vue 3 storylines plugin for preview mode and charts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "storylines-editor",
-    "version": "0.1.0",
+    "version": "1.0.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "storylines-editor",
-            "version": "0.1.0",
+            "version": "1.0.0",
             "dependencies": {
                 "@kangc/v-md-editor": "^2.3.17",
                 "@tailwindcss/typography": "^0.4.0",
@@ -21,6 +21,7 @@
                 "jszip": "^3.10.1",
                 "markdown-it": "^12.0.6",
                 "nouislider": "^15.5.0",
+                "ramp-storylines": "^3.0.2",
                 "uuid": "^9.0.0",
                 "vue": "^3.3.4",
                 "vue-class-component": "^8.0.0-rc.1",
@@ -101,31 +102,31 @@
             }
         },
         "node_modules/@babel/compat-data": {
-            "version": "7.22.20",
-            "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.22.20.tgz",
-            "integrity": "sha512-BQYjKbpXjoXwFW5jGqiizJQQT/aC7pFm9Ok1OWssonuguICi264lbgMzRp2ZMmRSlfkX6DsWDDcsrctK8Rwfiw==",
+            "version": "7.23.2",
+            "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.23.2.tgz",
+            "integrity": "sha512-0S9TQMmDHlqAZ2ITT95irXKfxN9bncq8ZCoJhun3nHL/lLUxd2NKBJYoNGWH7S0hz6fRQwWlAWn/ILM0C70KZQ==",
             "dev": true,
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/core": {
-            "version": "7.22.20",
-            "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.22.20.tgz",
-            "integrity": "sha512-Y6jd1ahLubuYweD/zJH+vvOY141v4f9igNQAQ+MBgq9JlHS2iTsZKn1aMsb3vGccZsXI16VzTBw52Xx0DWmtnA==",
+            "version": "7.23.0",
+            "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.23.0.tgz",
+            "integrity": "sha512-97z/ju/Jy1rZmDxybphrBuI+jtJjFVoz7Mr9yUQVVVi+DNZE333uFQeMOqcCIy1x3WYBIbWftUSLmbNXNT7qFQ==",
             "dev": true,
             "dependencies": {
                 "@ampproject/remapping": "^2.2.0",
                 "@babel/code-frame": "^7.22.13",
-                "@babel/generator": "^7.22.15",
+                "@babel/generator": "^7.23.0",
                 "@babel/helper-compilation-targets": "^7.22.15",
-                "@babel/helper-module-transforms": "^7.22.20",
-                "@babel/helpers": "^7.22.15",
-                "@babel/parser": "^7.22.16",
+                "@babel/helper-module-transforms": "^7.23.0",
+                "@babel/helpers": "^7.23.0",
+                "@babel/parser": "^7.23.0",
                 "@babel/template": "^7.22.15",
-                "@babel/traverse": "^7.22.20",
-                "@babel/types": "^7.22.19",
-                "convert-source-map": "^1.7.0",
+                "@babel/traverse": "^7.23.0",
+                "@babel/types": "^7.23.0",
+                "convert-source-map": "^2.0.0",
                 "debug": "^4.1.0",
                 "gensync": "^1.0.0-beta.2",
                 "json5": "^2.2.3",
@@ -149,12 +150,12 @@
             }
         },
         "node_modules/@babel/generator": {
-            "version": "7.22.15",
-            "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.22.15.tgz",
-            "integrity": "sha512-Zu9oWARBqeVOW0dZOjXc3JObrzuqothQ3y/n1kUtrjCoCPLkXUwMvOo/F/TCfoHMbWIFlWwpZtkZVb9ga4U2pA==",
+            "version": "7.23.0",
+            "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.23.0.tgz",
+            "integrity": "sha512-lN85QRR+5IbYrMWM6Y4pE/noaQtg4pNiqeNGX60eqOfo6gtEj6uw/JagelB8vVztSd7R6M5n1+PQkDbHbBRU4g==",
             "dev": true,
             "dependencies": {
-                "@babel/types": "^7.22.15",
+                "@babel/types": "^7.23.0",
                 "@jridgewell/gen-mapping": "^0.3.2",
                 "@jridgewell/trace-mapping": "^0.3.17",
                 "jsesc": "^2.5.1"
@@ -271,9 +272,9 @@
             }
         },
         "node_modules/@babel/helper-define-polyfill-provider": {
-            "version": "0.4.2",
-            "resolved": "https://registry.npmjs.org/@babel/helper-define-polyfill-provider/-/helper-define-polyfill-provider-0.4.2.tgz",
-            "integrity": "sha512-k0qnnOqHn5dK9pZpfD5XXZ9SojAITdCKRn2Lp6rnDGzIbaP0rHyMPk/4wsSxVBVz4RfN0q6VpXWP2pDGIoQ7hw==",
+            "version": "0.4.3",
+            "resolved": "https://registry.npmjs.org/@babel/helper-define-polyfill-provider/-/helper-define-polyfill-provider-0.4.3.tgz",
+            "integrity": "sha512-WBrLmuPP47n7PNwsZ57pqam6G/RGo1vw/87b0Blc53tZNGZ4x7YvZ6HgQe2vo1W/FR20OgjeZuGXzudPiXHFug==",
             "dev": true,
             "dependencies": {
                 "@babel/helper-compilation-targets": "^7.22.6",
@@ -296,13 +297,13 @@
             }
         },
         "node_modules/@babel/helper-function-name": {
-            "version": "7.22.5",
-            "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.22.5.tgz",
-            "integrity": "sha512-wtHSq6jMRE3uF2otvfuD3DIvVhOsSNshQl0Qrd7qC9oQJzHvOL4qQXlQn2916+CXGywIjpGuIkoyZRRxHPiNQQ==",
+            "version": "7.23.0",
+            "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.23.0.tgz",
+            "integrity": "sha512-OErEqsrxjZTJciZ4Oo+eoZqeW9UIiOcuYKRJA4ZAgV9myA+pOXhhmpfNCKjEH/auVfEYVFJ6y1Tc4r0eIApqiw==",
             "dev": true,
             "dependencies": {
-                "@babel/template": "^7.22.5",
-                "@babel/types": "^7.22.5"
+                "@babel/template": "^7.22.15",
+                "@babel/types": "^7.23.0"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -321,12 +322,12 @@
             }
         },
         "node_modules/@babel/helper-member-expression-to-functions": {
-            "version": "7.22.15",
-            "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.22.15.tgz",
-            "integrity": "sha512-qLNsZbgrNh0fDQBCPocSL8guki1hcPvltGDv/NxvUoABwFq7GkKSu1nRXeJkVZc+wJvne2E0RKQz+2SQrz6eAA==",
+            "version": "7.23.0",
+            "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.23.0.tgz",
+            "integrity": "sha512-6gfrPwh7OuT6gZyJZvd6WbTfrqAo7vm4xCzAXOusKqq/vWdKXphTpj5klHKNmRUU6/QRGlBsyU9mAIPaWHlqJA==",
             "dev": true,
             "dependencies": {
-                "@babel/types": "^7.22.15"
+                "@babel/types": "^7.23.0"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -345,9 +346,9 @@
             }
         },
         "node_modules/@babel/helper-module-transforms": {
-            "version": "7.22.20",
-            "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.22.20.tgz",
-            "integrity": "sha512-dLT7JVWIUUxKOs1UnJUBR3S70YK+pKX6AbJgB2vMIvEkZkrfJDbYDJesnPshtKV4LhDOR3Oc5YULeDizRek+5A==",
+            "version": "7.23.0",
+            "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.23.0.tgz",
+            "integrity": "sha512-WhDWw1tdrlT0gMgUJSlX0IQvoO1eN279zrAUbVB+KpV2c3Tylz8+GnKOLllCS6Z/iZQEyVYxhZVUdPTqs2YYPw==",
             "dev": true,
             "dependencies": {
                 "@babel/helper-environment-visitor": "^7.22.20",
@@ -495,14 +496,14 @@
             }
         },
         "node_modules/@babel/helpers": {
-            "version": "7.22.15",
-            "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.22.15.tgz",
-            "integrity": "sha512-7pAjK0aSdxOwR+CcYAqgWOGy5dcfvzsTIfFTb2odQqW47MDfv14UaJDY6eng8ylM2EaeKXdxaSWESbkmaQHTmw==",
+            "version": "7.23.2",
+            "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.23.2.tgz",
+            "integrity": "sha512-lzchcp8SjTSVe/fPmLwtWVBFC7+Tbn8LGHDVfDp9JGxpAY5opSaEFgt8UQvrnECWOTdji2mOWMz1rOhkHscmGQ==",
             "dev": true,
             "dependencies": {
                 "@babel/template": "^7.22.15",
-                "@babel/traverse": "^7.22.15",
-                "@babel/types": "^7.22.15"
+                "@babel/traverse": "^7.23.2",
+                "@babel/types": "^7.23.0"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -522,9 +523,9 @@
             }
         },
         "node_modules/@babel/parser": {
-            "version": "7.22.16",
-            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.22.16.tgz",
-            "integrity": "sha512-+gPfKv8UWeKKeJTUxe59+OobVcrYHETCsORl61EmSkmgymguYk/X5bp7GuUIXaFsc6y++v8ZxPsLSSuujqDphA==",
+            "version": "7.23.0",
+            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.23.0.tgz",
+            "integrity": "sha512-vvPKKdMemU85V9WE/l5wZEmImpCtLqbnTvqDS2U1fJ96KrxoW7KrXhNsNCblQlg8Ck4b85yxdTyelsMUgFUXiw==",
             "bin": {
                 "parser": "bin/babel-parser.js"
             },
@@ -582,14 +583,14 @@
             }
         },
         "node_modules/@babel/plugin-proposal-decorators": {
-            "version": "7.22.15",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-decorators/-/plugin-proposal-decorators-7.22.15.tgz",
-            "integrity": "sha512-kc0VvbbUyKelvzcKOSyQUSVVXS5pT3UhRB0e3c9An86MvLqs+gx0dN4asllrDluqSa3m9YyooXKGOFVomnyFkg==",
+            "version": "7.23.2",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-decorators/-/plugin-proposal-decorators-7.23.2.tgz",
+            "integrity": "sha512-eR0gJQc830fJVGz37oKLvt9W9uUIQSAovUl0e9sJ3YeO09dlcoBVYD3CLrjCj4qHdXmfiyTyFt8yeQYSN5fxLg==",
             "dev": true,
             "dependencies": {
                 "@babel/helper-create-class-features-plugin": "^7.22.15",
                 "@babel/helper-plugin-utils": "^7.22.5",
-                "@babel/helper-replace-supers": "^7.22.9",
+                "@babel/helper-replace-supers": "^7.22.20",
                 "@babel/helper-split-export-declaration": "^7.22.6",
                 "@babel/plugin-syntax-decorators": "^7.22.10"
             },
@@ -893,14 +894,14 @@
             }
         },
         "node_modules/@babel/plugin-transform-async-generator-functions": {
-            "version": "7.22.15",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-generator-functions/-/plugin-transform-async-generator-functions-7.22.15.tgz",
-            "integrity": "sha512-jBm1Es25Y+tVoTi5rfd5t1KLmL8ogLKpXszboWOTTtGFGz2RKnQe2yn7HbZ+kb/B8N0FVSGQo874NSlOU1T4+w==",
+            "version": "7.23.2",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-generator-functions/-/plugin-transform-async-generator-functions-7.23.2.tgz",
+            "integrity": "sha512-BBYVGxbDVHfoeXbOwcagAkOQAm9NxoTdMGfTqghu1GrvadSaw6iW3Je6IcL5PNOw8VwjxqBECXy50/iCQSY/lQ==",
             "dev": true,
             "dependencies": {
-                "@babel/helper-environment-visitor": "^7.22.5",
+                "@babel/helper-environment-visitor": "^7.22.20",
                 "@babel/helper-plugin-utils": "^7.22.5",
-                "@babel/helper-remap-async-to-generator": "^7.22.9",
+                "@babel/helper-remap-async-to-generator": "^7.22.20",
                 "@babel/plugin-syntax-async-generators": "^7.8.4"
             },
             "engines": {
@@ -943,9 +944,9 @@
             }
         },
         "node_modules/@babel/plugin-transform-block-scoping": {
-            "version": "7.22.15",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.22.15.tgz",
-            "integrity": "sha512-G1czpdJBZCtngoK1sJgloLiOHUnkb/bLZwqVZD8kXmq0ZnVfTTWUcs9OWtp0mBtYJ+4LQY1fllqBkOIPhXmFmw==",
+            "version": "7.23.0",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.23.0.tgz",
+            "integrity": "sha512-cOsrbmIOXmf+5YbL99/S49Y3j46k/T16b9ml8bm9lP6N9US5iQ2yBK7gpui1pg0V/WMcXdkfKbTb7HXq9u+v4g==",
             "dev": true,
             "dependencies": {
                 "@babel/helper-plugin-utils": "^7.22.5"
@@ -1030,9 +1031,9 @@
             }
         },
         "node_modules/@babel/plugin-transform-destructuring": {
-            "version": "7.22.15",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.22.15.tgz",
-            "integrity": "sha512-HzG8sFl1ZVGTme74Nw+X01XsUTqERVQ6/RLHo3XjGRzm7XD6QTtfS3NJotVgCGy8BzkDqRjRBD8dAyJn5TuvSQ==",
+            "version": "7.23.0",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.23.0.tgz",
+            "integrity": "sha512-vaMdgNXFkYrB+8lbgniSYWHsgqK5gjaMNcc84bMIOMRLH0L9AqYq3hwMdvnyqj1OPqea8UtjPEuS/DCenah1wg==",
             "dev": true,
             "dependencies": {
                 "@babel/helper-plugin-utils": "^7.22.5"
@@ -1218,12 +1219,12 @@
             }
         },
         "node_modules/@babel/plugin-transform-modules-amd": {
-            "version": "7.22.5",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-amd/-/plugin-transform-modules-amd-7.22.5.tgz",
-            "integrity": "sha512-R+PTfLTcYEmb1+kK7FNkhQ1gP4KgjpSO6HfH9+f8/yfp2Nt3ggBjiVpRwmwTlfqZLafYKJACy36yDXlEmI9HjQ==",
+            "version": "7.23.0",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-amd/-/plugin-transform-modules-amd-7.23.0.tgz",
+            "integrity": "sha512-xWT5gefv2HGSm4QHtgc1sYPbseOyf+FFDo2JbpE25GWl5BqTGO9IMwTYJRoIdjsF85GE+VegHxSCUt5EvoYTAw==",
             "dev": true,
             "dependencies": {
-                "@babel/helper-module-transforms": "^7.22.5",
+                "@babel/helper-module-transforms": "^7.23.0",
                 "@babel/helper-plugin-utils": "^7.22.5"
             },
             "engines": {
@@ -1234,12 +1235,12 @@
             }
         },
         "node_modules/@babel/plugin-transform-modules-commonjs": {
-            "version": "7.22.15",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.22.15.tgz",
-            "integrity": "sha512-jWL4eh90w0HQOTKP2MoXXUpVxilxsB2Vl4ji69rSjS3EcZ/v4sBmn+A3NpepuJzBhOaEBbR7udonlHHn5DWidg==",
+            "version": "7.23.0",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.23.0.tgz",
+            "integrity": "sha512-32Xzss14/UVc7k9g775yMIvkVK8xwKE0DPdP5JTapr3+Z9w4tzeOuLNY6BXDQR6BdnzIlXnCGAzsk/ICHBLVWQ==",
             "dev": true,
             "dependencies": {
-                "@babel/helper-module-transforms": "^7.22.15",
+                "@babel/helper-module-transforms": "^7.23.0",
                 "@babel/helper-plugin-utils": "^7.22.5",
                 "@babel/helper-simple-access": "^7.22.5"
             },
@@ -1251,15 +1252,15 @@
             }
         },
         "node_modules/@babel/plugin-transform-modules-systemjs": {
-            "version": "7.22.11",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.22.11.tgz",
-            "integrity": "sha512-rIqHmHoMEOhI3VkVf5jQ15l539KrwhzqcBO6wdCNWPWc/JWt9ILNYNUssbRpeq0qWns8svuw8LnMNCvWBIJ8wA==",
+            "version": "7.23.0",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.23.0.tgz",
+            "integrity": "sha512-qBej6ctXZD2f+DhlOC9yO47yEYgUh5CZNz/aBoH4j/3NOlRfJXJbY7xDQCqQVf9KbrqGzIWER1f23doHGrIHFg==",
             "dev": true,
             "dependencies": {
                 "@babel/helper-hoist-variables": "^7.22.5",
-                "@babel/helper-module-transforms": "^7.22.9",
+                "@babel/helper-module-transforms": "^7.23.0",
                 "@babel/helper-plugin-utils": "^7.22.5",
-                "@babel/helper-validator-identifier": "^7.22.5"
+                "@babel/helper-validator-identifier": "^7.22.20"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -1399,9 +1400,9 @@
             }
         },
         "node_modules/@babel/plugin-transform-optional-chaining": {
-            "version": "7.22.15",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-optional-chaining/-/plugin-transform-optional-chaining-7.22.15.tgz",
-            "integrity": "sha512-ngQ2tBhq5vvSJw2Q2Z9i7ealNkpDMU0rGWnHPKqRZO0tzZ5tlaoz4hDvhXioOoaE0X2vfNss1djwg0DXlfu30A==",
+            "version": "7.23.0",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-optional-chaining/-/plugin-transform-optional-chaining-7.23.0.tgz",
+            "integrity": "sha512-sBBGXbLJjxTzLBF5rFWaikMnOGOk/BmK6vVByIdEggZ7Vn6CvWXZyRkkLFK6WE0IF8jSliyOkUN6SScFgzCM0g==",
             "dev": true,
             "dependencies": {
                 "@babel/helper-plugin-utils": "^7.22.5",
@@ -1511,16 +1512,16 @@
             }
         },
         "node_modules/@babel/plugin-transform-runtime": {
-            "version": "7.22.15",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.22.15.tgz",
-            "integrity": "sha512-tEVLhk8NRZSmwQ0DJtxxhTrCht1HVo8VaMzYT4w6lwyKBuHsgoioAUA7/6eT2fRfc5/23fuGdlwIxXhRVgWr4g==",
+            "version": "7.23.2",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.23.2.tgz",
+            "integrity": "sha512-XOntj6icgzMS58jPVtQpiuF6ZFWxQiJavISGx5KGjRj+3gqZr8+N6Kx+N9BApWzgS+DOjIZfXXj0ZesenOWDyA==",
             "dev": true,
             "dependencies": {
                 "@babel/helper-module-imports": "^7.22.15",
                 "@babel/helper-plugin-utils": "^7.22.5",
-                "babel-plugin-polyfill-corejs2": "^0.4.5",
-                "babel-plugin-polyfill-corejs3": "^0.8.3",
-                "babel-plugin-polyfill-regenerator": "^0.5.2",
+                "babel-plugin-polyfill-corejs2": "^0.4.6",
+                "babel-plugin-polyfill-corejs3": "^0.8.5",
+                "babel-plugin-polyfill-regenerator": "^0.5.3",
                 "semver": "^6.3.1"
             },
             "engines": {
@@ -1679,12 +1680,12 @@
             }
         },
         "node_modules/@babel/preset-env": {
-            "version": "7.22.20",
-            "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.22.20.tgz",
-            "integrity": "sha512-11MY04gGC4kSzlPHRfvVkNAZhUxOvm7DCJ37hPDnUENwe06npjIRAfInEMTGSb4LZK5ZgDFkv5hw0lGebHeTyg==",
+            "version": "7.23.2",
+            "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.23.2.tgz",
+            "integrity": "sha512-BW3gsuDD+rvHL2VO2SjAUNTBe5YrjsTiDyqamPDWY723na3/yPQ65X5oQkFVJZ0o50/2d+svm1rkPoJeR1KxVQ==",
             "dev": true,
             "dependencies": {
-                "@babel/compat-data": "^7.22.20",
+                "@babel/compat-data": "^7.23.2",
                 "@babel/helper-compilation-targets": "^7.22.15",
                 "@babel/helper-plugin-utils": "^7.22.5",
                 "@babel/helper-validator-option": "^7.22.15",
@@ -1710,15 +1711,15 @@
                 "@babel/plugin-syntax-top-level-await": "^7.14.5",
                 "@babel/plugin-syntax-unicode-sets-regex": "^7.18.6",
                 "@babel/plugin-transform-arrow-functions": "^7.22.5",
-                "@babel/plugin-transform-async-generator-functions": "^7.22.15",
+                "@babel/plugin-transform-async-generator-functions": "^7.23.2",
                 "@babel/plugin-transform-async-to-generator": "^7.22.5",
                 "@babel/plugin-transform-block-scoped-functions": "^7.22.5",
-                "@babel/plugin-transform-block-scoping": "^7.22.15",
+                "@babel/plugin-transform-block-scoping": "^7.23.0",
                 "@babel/plugin-transform-class-properties": "^7.22.5",
                 "@babel/plugin-transform-class-static-block": "^7.22.11",
                 "@babel/plugin-transform-classes": "^7.22.15",
                 "@babel/plugin-transform-computed-properties": "^7.22.5",
-                "@babel/plugin-transform-destructuring": "^7.22.15",
+                "@babel/plugin-transform-destructuring": "^7.23.0",
                 "@babel/plugin-transform-dotall-regex": "^7.22.5",
                 "@babel/plugin-transform-duplicate-keys": "^7.22.5",
                 "@babel/plugin-transform-dynamic-import": "^7.22.11",
@@ -1730,9 +1731,9 @@
                 "@babel/plugin-transform-literals": "^7.22.5",
                 "@babel/plugin-transform-logical-assignment-operators": "^7.22.11",
                 "@babel/plugin-transform-member-expression-literals": "^7.22.5",
-                "@babel/plugin-transform-modules-amd": "^7.22.5",
-                "@babel/plugin-transform-modules-commonjs": "^7.22.15",
-                "@babel/plugin-transform-modules-systemjs": "^7.22.11",
+                "@babel/plugin-transform-modules-amd": "^7.23.0",
+                "@babel/plugin-transform-modules-commonjs": "^7.23.0",
+                "@babel/plugin-transform-modules-systemjs": "^7.23.0",
                 "@babel/plugin-transform-modules-umd": "^7.22.5",
                 "@babel/plugin-transform-named-capturing-groups-regex": "^7.22.5",
                 "@babel/plugin-transform-new-target": "^7.22.5",
@@ -1741,7 +1742,7 @@
                 "@babel/plugin-transform-object-rest-spread": "^7.22.15",
                 "@babel/plugin-transform-object-super": "^7.22.5",
                 "@babel/plugin-transform-optional-catch-binding": "^7.22.11",
-                "@babel/plugin-transform-optional-chaining": "^7.22.15",
+                "@babel/plugin-transform-optional-chaining": "^7.23.0",
                 "@babel/plugin-transform-parameters": "^7.22.15",
                 "@babel/plugin-transform-private-methods": "^7.22.5",
                 "@babel/plugin-transform-private-property-in-object": "^7.22.11",
@@ -1758,10 +1759,10 @@
                 "@babel/plugin-transform-unicode-regex": "^7.22.5",
                 "@babel/plugin-transform-unicode-sets-regex": "^7.22.5",
                 "@babel/preset-modules": "0.1.6-no-external-plugins",
-                "@babel/types": "^7.22.19",
-                "babel-plugin-polyfill-corejs2": "^0.4.5",
-                "babel-plugin-polyfill-corejs3": "^0.8.3",
-                "babel-plugin-polyfill-regenerator": "^0.5.2",
+                "@babel/types": "^7.23.0",
+                "babel-plugin-polyfill-corejs2": "^0.4.6",
+                "babel-plugin-polyfill-corejs3": "^0.8.5",
+                "babel-plugin-polyfill-regenerator": "^0.5.3",
                 "core-js-compat": "^3.31.0",
                 "semver": "^6.3.1"
             },
@@ -1802,9 +1803,9 @@
             "dev": true
         },
         "node_modules/@babel/runtime": {
-            "version": "7.22.15",
-            "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.22.15.tgz",
-            "integrity": "sha512-T0O+aa+4w0u06iNmapipJXMV4HoUir03hpx3/YqXXhu9xim3w+dVphjFWl1OH8NbZHw5Lbm9k45drDkgq2VNNA==",
+            "version": "7.23.2",
+            "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.23.2.tgz",
+            "integrity": "sha512-mM8eg4yl5D6i3lu2QKPuPH4FArvJ8KhTofbE7jwMUv9KX5mBvwPAqnV3MlyBNqdp9RyRKP6Yck8TrfYrPvX3bg==",
             "dependencies": {
                 "regenerator-runtime": "^0.14.0"
             },
@@ -1827,19 +1828,19 @@
             }
         },
         "node_modules/@babel/traverse": {
-            "version": "7.22.20",
-            "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.22.20.tgz",
-            "integrity": "sha512-eU260mPZbU7mZ0N+X10pxXhQFMGTeLb9eFS0mxehS8HZp9o1uSnFeWQuG1UPrlxgA7QoUzFhOnilHDp0AXCyHw==",
+            "version": "7.23.2",
+            "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.23.2.tgz",
+            "integrity": "sha512-azpe59SQ48qG6nu2CzcMLbxUudtN+dOM9kDbUqGq3HXUJRlo7i8fvPoxQUzYgLZ4cMVmuZgm8vvBpNeRhd6XSw==",
             "dev": true,
             "dependencies": {
                 "@babel/code-frame": "^7.22.13",
-                "@babel/generator": "^7.22.15",
+                "@babel/generator": "^7.23.0",
                 "@babel/helper-environment-visitor": "^7.22.20",
-                "@babel/helper-function-name": "^7.22.5",
+                "@babel/helper-function-name": "^7.23.0",
                 "@babel/helper-hoist-variables": "^7.22.5",
                 "@babel/helper-split-export-declaration": "^7.22.6",
-                "@babel/parser": "^7.22.16",
-                "@babel/types": "^7.22.19",
+                "@babel/parser": "^7.23.0",
+                "@babel/types": "^7.23.0",
                 "debug": "^4.1.0",
                 "globals": "^11.1.0"
             },
@@ -1848,13 +1849,13 @@
             }
         },
         "node_modules/@babel/types": {
-            "version": "7.22.19",
-            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.22.19.tgz",
-            "integrity": "sha512-P7LAw/LbojPzkgp5oznjE6tQEIWbp4PkkfrZDINTro9zgBRtI324/EYsiSI7lhPbpIQ+DCeR2NNmMWANGGfZsg==",
+            "version": "7.23.0",
+            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.23.0.tgz",
+            "integrity": "sha512-0oIyUfKoI3mSqMvsxBdclDwxXKXAUA8v/apZbc+iSyARYou1o8ZGDxbUYyLFoW2arqS2jDGqJuZvv1d/io1axg==",
             "dev": true,
             "dependencies": {
                 "@babel/helper-string-parser": "^7.22.5",
-                "@babel/helper-validator-identifier": "^7.22.19",
+                "@babel/helper-validator-identifier": "^7.22.20",
                 "to-fast-properties": "^2.0.0"
             },
             "engines": {
@@ -1926,12 +1927,12 @@
             }
         },
         "node_modules/@intlify/core-base": {
-            "version": "9.4.1",
-            "resolved": "https://registry.npmjs.org/@intlify/core-base/-/core-base-9.4.1.tgz",
-            "integrity": "sha512-WIwx+elsZbxSMxRG5+LC+utRohFvmZMoDevfKOfnYMLbpCjCSavqTfHJAtfsY6ruowzqXeKkeLhRHbYbjoJx5g==",
+            "version": "9.5.0",
+            "resolved": "https://registry.npmjs.org/@intlify/core-base/-/core-base-9.5.0.tgz",
+            "integrity": "sha512-y3ufM1RJbI/DSmJf3lYs9ACq3S/iRvaSsE3rPIk0MGH7fp+JxU6rdryv/EYcwfcr3Y1aHFlCBir6S391hRZ57w==",
             "dependencies": {
-                "@intlify/message-compiler": "9.4.1",
-                "@intlify/shared": "9.4.1"
+                "@intlify/message-compiler": "9.5.0",
+                "@intlify/shared": "9.5.0"
             },
             "engines": {
                 "node": ">= 16"
@@ -1941,11 +1942,11 @@
             }
         },
         "node_modules/@intlify/message-compiler": {
-            "version": "9.4.1",
-            "resolved": "https://registry.npmjs.org/@intlify/message-compiler/-/message-compiler-9.4.1.tgz",
-            "integrity": "sha512-aN2N+dUx320108QhH51Ycd2LEpZ+NKbzyQ2kjjhqMcxhHdxtOnkgdx+MDBhOy/CObwBmhC3Nygzc6hNlfKvPNw==",
+            "version": "9.5.0",
+            "resolved": "https://registry.npmjs.org/@intlify/message-compiler/-/message-compiler-9.5.0.tgz",
+            "integrity": "sha512-CAhVNfEZcOVFg0/5MNyt+OFjvs4J/ARjCj2b+54/FvFP0EDJI5lIqMTSDBE7k0atMROSP0SvWCkwu/AZ5xkK1g==",
             "dependencies": {
-                "@intlify/shared": "9.4.1",
+                "@intlify/shared": "9.5.0",
                 "source-map-js": "^1.0.2"
             },
             "engines": {
@@ -1956,9 +1957,9 @@
             }
         },
         "node_modules/@intlify/shared": {
-            "version": "9.4.1",
-            "resolved": "https://registry.npmjs.org/@intlify/shared/-/shared-9.4.1.tgz",
-            "integrity": "sha512-A51elBmZWf1FS80inf/32diO9DeXoqg9GR9aUDHFcfHoNDuT46Q+fpPOdj8jiJnSHSBh8E1E+6qWRhAZXdK3Ng==",
+            "version": "9.5.0",
+            "resolved": "https://registry.npmjs.org/@intlify/shared/-/shared-9.5.0.tgz",
+            "integrity": "sha512-tAxV14LMXZDZbu32XzLMTsowNlgJNmLwWHYzvMUl6L8gvQeoYiZONjY7AUsqZW8TOZDX9lfvF6adPkk9FSRdDA==",
             "engines": {
                 "node": ">= 16"
             },
@@ -2245,9 +2246,9 @@
             }
         },
         "node_modules/@types/express": {
-            "version": "4.17.17",
-            "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.17.tgz",
-            "integrity": "sha512-Q4FmmuLGBG58btUnfS1c1r/NQdlp3DMfGDGig8WhfpA2YRUtEkxAjkZb0yvplJGYdF1fsQ81iMDcH24sSCNC/Q==",
+            "version": "4.17.19",
+            "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.19.tgz",
+            "integrity": "sha512-UtOfBtzN9OvpZPPbnnYunfjM7XCI4jyk1NvnFhTVz5krYAnW4o5DCoIekvms+8ApqhB4+9wSge1kBijdfTSmfg==",
             "dev": true,
             "dependencies": {
                 "@types/body-parser": "*",
@@ -2257,9 +2258,9 @@
             }
         },
         "node_modules/@types/express-serve-static-core": {
-            "version": "4.17.36",
-            "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.36.tgz",
-            "integrity": "sha512-zbivROJ0ZqLAtMzgzIUC4oNqDG9iF0lSsAqpOD9kbs5xcIM3dTiyuHvBc7R8MtWBp3AAWGaovJa+wzWPjLYW7Q==",
+            "version": "4.17.37",
+            "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.37.tgz",
+            "integrity": "sha512-ZohaCYTgGFcOP7u6aJOhY9uIZQgZ2vxC2yWoArY+FeDXlqeH66ZVBjgvg+RLVAS/DWNq4Ap9ZXu1+SUQiiWYMg==",
             "dev": true,
             "dependencies": {
                 "@types/node": "*",
@@ -2330,15 +2331,15 @@
             }
         },
         "node_modules/@types/mdurl": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/@types/mdurl/-/mdurl-1.0.2.tgz",
-            "integrity": "sha512-eC4U9MlIcu2q0KQmXszyn5Akca/0jrQmwDRgpAMJai7qBWq4amIQhZyNau4VYGtCeALvW1/NtjzJJ567aZxfKA==",
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/@types/mdurl/-/mdurl-1.0.3.tgz",
+            "integrity": "sha512-T5k6kTXak79gwmIOaDF2UUQXFbnBE0zBUzF20pz7wDYu0RQMzWg+Ml/Pz50214NsFHBITkoi5VtdjFZnJ2ijjA==",
             "dev": true
         },
         "node_modules/@types/mime": {
-            "version": "1.3.2",
-            "resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.2.tgz",
-            "integrity": "sha512-YATxVxgRqNH6nHEIsvg6k2Boc1JHI9ZbH5iWFFv/MTkchz3b1ieGDa5T0a9RznNdI0KhVbdbWSN+KWWrQZRxTw==",
+            "version": "1.3.3",
+            "resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.3.tgz",
+            "integrity": "sha512-Ys+/St+2VF4+xuY6+kDIXGxbNRO0mesVg0bbxEfB97Od1Vjpjx9KD1qxs64Gcb3CWPirk9Xe+PT4YiiHQ9T+eg==",
             "dev": true
         },
         "node_modules/@types/minimatch": {
@@ -2347,20 +2348,23 @@
             "integrity": "sha512-K0VQKziLUWkVKiRVrx4a40iPaxTUefQmjtkQofBkYRcoaaL/8rhwDWww9qWbrgicNOgnpIsMxyNIUM4+n6dUIA=="
         },
         "node_modules/@types/minimist": {
-            "version": "1.2.2",
-            "resolved": "https://registry.npmjs.org/@types/minimist/-/minimist-1.2.2.tgz",
-            "integrity": "sha512-jhuKLIRrhvCPLqwPcx6INqmKeiA5EWrsCOPhrlFSrbrmU4ZMPjj5Ul/oLCMDO98XRUIwVm78xICz4EPCektzeQ==",
+            "version": "1.2.3",
+            "resolved": "https://registry.npmjs.org/@types/minimist/-/minimist-1.2.3.tgz",
+            "integrity": "sha512-ZYFzrvyWUNhaPomn80dsMNgMeXxNWZBdkuG/hWlUvXvbdUH8ZERNBGXnU87McuGcWDsyzX2aChCv/SVN348k3A==",
             "dev": true
         },
         "node_modules/@types/node": {
-            "version": "20.6.2",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-20.6.2.tgz",
-            "integrity": "sha512-Y+/1vGBHV/cYk6OI1Na/LHzwnlNCAfU3ZNGrc1LdRe/LAIbdDPTTv/HU3M7yXN448aTVDq3eKRm2cg7iKLb8gw=="
+            "version": "20.8.4",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-20.8.4.tgz",
+            "integrity": "sha512-ZVPnqU58giiCjSxjVUESDtdPk4QR5WQhhINbc9UBrKLU68MX5BF6kbQzTrkwbolyr0X8ChBpXfavr5mZFKZQ5A==",
+            "dependencies": {
+                "undici-types": "~5.25.1"
+            }
         },
         "node_modules/@types/normalize-package-data": {
-            "version": "2.4.1",
-            "resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.1.tgz",
-            "integrity": "sha512-Gj7cI7z+98M282Tqmp2K5EIsoouUEzbBJhQQzDE3jSIRk6r9gsz0oUokqIUR4u1R3dMHo0pDHM7sNOHyhulypw==",
+            "version": "2.4.2",
+            "resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.2.tgz",
+            "integrity": "sha512-lqa4UEhhv/2sjjIQgjX8B+RBjj47eo0mzGasklVJ78UKGQY1r0VpB9XHDaZZO9qzEFDdy4MrXLuEaSmPrPSe/A==",
             "dev": true
         },
         "node_modules/@types/parse-json": {
@@ -2381,15 +2385,15 @@
             "dev": true
         },
         "node_modules/@types/range-parser": {
-            "version": "1.2.4",
-            "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.4.tgz",
-            "integrity": "sha512-EEhsLsD6UsDM1yFhAvy0Cjr6VwmpMWqFBCb9w07wVugF7w9nfajxLuVmngTIpgS6svCnm6Vaw+MZhoDCKnOfsw==",
+            "version": "1.2.5",
+            "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.5.tgz",
+            "integrity": "sha512-xrO9OoVPqFuYyR/loIHjnbvvyRZREYKLjxV4+dY6v3FQR3stQ9ZxIGkaclF7YhI9hfjpuTbu14hZEy94qKLtOA==",
             "dev": true
         },
         "node_modules/@types/send": {
-            "version": "0.17.1",
-            "resolved": "https://registry.npmjs.org/@types/send/-/send-0.17.1.tgz",
-            "integrity": "sha512-Cwo8LE/0rnvX7kIIa3QHCkcuF21c05Ayb0ZfxPiv0W8VRiZiNW/WuRupHKpqqGVGf7SUA44QSOUKaEd9lIrd/Q==",
+            "version": "0.17.2",
+            "resolved": "https://registry.npmjs.org/@types/send/-/send-0.17.2.tgz",
+            "integrity": "sha512-aAG6yRf6r0wQ29bkS+x97BIs64ZLxeE/ARwyS6wrldMm3C1MdKwCcnnEwMC1slI8wuxJOpiUH9MioC0A0i+GJw==",
             "dev": true,
             "dependencies": {
                 "@types/mime": "^1",
@@ -2397,9 +2401,9 @@
             }
         },
         "node_modules/@types/serve-static": {
-            "version": "1.15.2",
-            "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.15.2.tgz",
-            "integrity": "sha512-J2LqtvFYCzaj8pVYKw8klQXrLLk7TBZmQ4ShlcdkELFKGwGMfevMLneMMRkMgZxotOD9wg497LpC7O8PcvAmfw==",
+            "version": "1.15.3",
+            "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.15.3.tgz",
+            "integrity": "sha512-yVRvFsEMrv7s0lGhzrggJjNOSmZCdgCjw9xWrPr/kNNLp6FaDfMC1KaYl3TSJ0c58bECwNBMoQrZJ8hA8E1eFg==",
             "dev": true,
             "dependencies": {
                 "@types/http-errors": "*",
@@ -2408,9 +2412,9 @@
             }
         },
         "node_modules/@types/source-list-map": {
-            "version": "0.1.2",
-            "resolved": "https://registry.npmjs.org/@types/source-list-map/-/source-list-map-0.1.2.tgz",
-            "integrity": "sha512-K5K+yml8LTo9bWJI/rECfIPrGgxdpeNbj+d53lwN4QjW1MCwlkhUms+gtdzigTeUyBr09+u8BwOIY3MXvHdcsA==",
+            "version": "0.1.3",
+            "resolved": "https://registry.npmjs.org/@types/source-list-map/-/source-list-map-0.1.3.tgz",
+            "integrity": "sha512-I9R/7fUjzUOyDy6AFkehCK711wWoAXEaBi80AfjZt1lIkbe6AcXKd3ckQc3liMvQExWvfOeh/8CtKzrfUFN5gA==",
             "dev": true
         },
         "node_modules/@types/tapable": {
@@ -2434,9 +2438,9 @@
             "integrity": "sha512-oh8q2Zc32S6gd/j50GowEjKLoOVOwHP/bWVjKJInBwQqdOYMdPrf1oVlelTlyfFK3CKxL1uahMDAr+vy8T7yMQ=="
         },
         "node_modules/@types/webpack": {
-            "version": "4.41.33",
-            "resolved": "https://registry.npmjs.org/@types/webpack/-/webpack-4.41.33.tgz",
-            "integrity": "sha512-PPajH64Ft2vWevkerISMtnZ8rTs4YmRbs+23c402J0INmxDKCrhZNvwZYtzx96gY2wAtXdrK1BS2fiC8MlLr3g==",
+            "version": "4.41.34",
+            "resolved": "https://registry.npmjs.org/@types/webpack/-/webpack-4.41.34.tgz",
+            "integrity": "sha512-CN2aOGrR3zbMc2v+cKqzaClYP1ldkpPOgtdNvgX+RmlWCSWxHxpzz6WSCVQZRkF8D60ROlkRzAoEpgjWQ+bd2g==",
             "dev": true,
             "dependencies": {
                 "@types/node": "*",
@@ -2461,15 +2465,15 @@
             }
         },
         "node_modules/@types/webpack-env": {
-            "version": "1.18.1",
-            "resolved": "https://registry.npmjs.org/@types/webpack-env/-/webpack-env-1.18.1.tgz",
-            "integrity": "sha512-D0HJET2/UY6k9L6y3f5BL+IDxZmPkYmPT4+qBrRdmRLYRuV0qNKizMgTvYxXZYn+36zjPeoDZAEYBCM6XB+gww==",
+            "version": "1.18.2",
+            "resolved": "https://registry.npmjs.org/@types/webpack-env/-/webpack-env-1.18.2.tgz",
+            "integrity": "sha512-BFqcTHHTrrI8EBmIzNAmLPP3IqtEG9J1IPFWbPeS/F0/TGNmo0pI5svOa7JbMF9vSCXQCvJWT2gxLJNVuf9blw==",
             "dev": true
         },
         "node_modules/@types/webpack-sources": {
-            "version": "3.2.0",
-            "resolved": "https://registry.npmjs.org/@types/webpack-sources/-/webpack-sources-3.2.0.tgz",
-            "integrity": "sha512-Ft7YH3lEVRQ6ls8k4Ff1oB4jN6oy/XmU6tQISKdhfh+1mR+viZFphS6WL0IrtDOzvefmJg5a0s7ZQoRXwqTEFg==",
+            "version": "3.2.1",
+            "resolved": "https://registry.npmjs.org/@types/webpack-sources/-/webpack-sources-3.2.1.tgz",
+            "integrity": "sha512-iLC3Fsx62ejm3ST3PQ8vBMC54Rb3EoCprZjeJGI5q+9QjfDLGt9jeg/k245qz1G9AQnORGk0vqPicJFPT1QODQ==",
             "dev": true,
             "dependencies": {
                 "@types/node": "*",
@@ -3490,9 +3494,9 @@
             "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ=="
         },
         "node_modules/@vue/compiler-sfc/node_modules/postcss": {
-            "version": "8.4.30",
-            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.30.tgz",
-            "integrity": "sha512-7ZEao1g4kd68l97aWG/etQKPKq07us0ieSZ2TnFDk11i0ZfDW2AwKHYU8qv4MZKqN2fdBfg+7q0ES06UA73C1g==",
+            "version": "8.4.31",
+            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",
+            "integrity": "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==",
             "funding": [
                 {
                     "type": "opencollective",
@@ -3567,9 +3571,9 @@
             "dev": true
         },
         "node_modules/@vue/devtools-api": {
-            "version": "6.5.0",
-            "resolved": "https://registry.npmjs.org/@vue/devtools-api/-/devtools-api-6.5.0.tgz",
-            "integrity": "sha512-o9KfBeaBmCKl10usN4crU53fYtC1r7jJwdGKjPT24t348rHxgfpZ0xL3Xm/gLUYnc0oTp8LAmrxOeLyu6tbk2Q=="
+            "version": "6.5.1",
+            "resolved": "https://registry.npmjs.org/@vue/devtools-api/-/devtools-api-6.5.1.tgz",
+            "integrity": "sha512-+KpckaAQyfbvshdDW5xQylLni1asvNSGme1JFs8I1+/H5pHEhqUKMEQD/qn3Nx5+/nycBq11qAEi8lk+LXI2dA=="
         },
         "node_modules/@vue/eslint-config-prettier": {
             "version": "6.0.0",
@@ -4756,9 +4760,9 @@
             "dev": true
         },
         "node_modules/axios": {
-            "version": "1.5.0",
-            "resolved": "https://registry.npmjs.org/axios/-/axios-1.5.0.tgz",
-            "integrity": "sha512-D4DdjDo5CY50Qms0qGQTTw6Q44jl7zRwY7bthds06pUGfChBCTcQs+N743eFWGEd6pRTMd6A+I87aWyFV5wiZQ==",
+            "version": "1.5.1",
+            "resolved": "https://registry.npmjs.org/axios/-/axios-1.5.1.tgz",
+            "integrity": "sha512-Q28iYCWzNHjAm+yEAot5QaAMxhMghWLFVf7rRdwhUI+c2jix2DUXjAHXVi+s1ibs3mjPO/cCgbA++3BjD0vP/A==",
             "dependencies": {
                 "follow-redirects": "^1.15.0",
                 "form-data": "^4.0.0",
@@ -4866,13 +4870,13 @@
             }
         },
         "node_modules/babel-plugin-polyfill-corejs2": {
-            "version": "0.4.5",
-            "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs2/-/babel-plugin-polyfill-corejs2-0.4.5.tgz",
-            "integrity": "sha512-19hwUH5FKl49JEsvyTcoHakh6BE0wgXLLptIyKZ3PijHc/Ci521wygORCUCCred+E/twuqRyAkE02BAWPmsHOg==",
+            "version": "0.4.6",
+            "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs2/-/babel-plugin-polyfill-corejs2-0.4.6.tgz",
+            "integrity": "sha512-jhHiWVZIlnPbEUKSSNb9YoWcQGdlTLq7z1GHL4AjFxaoOUMuuEVJ+Y4pAaQUGOGk93YsVCKPbqbfw3m0SM6H8Q==",
             "dev": true,
             "dependencies": {
                 "@babel/compat-data": "^7.22.6",
-                "@babel/helper-define-polyfill-provider": "^0.4.2",
+                "@babel/helper-define-polyfill-provider": "^0.4.3",
                 "semver": "^6.3.1"
             },
             "peerDependencies": {
@@ -4889,25 +4893,25 @@
             }
         },
         "node_modules/babel-plugin-polyfill-corejs3": {
-            "version": "0.8.3",
-            "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs3/-/babel-plugin-polyfill-corejs3-0.8.3.tgz",
-            "integrity": "sha512-z41XaniZL26WLrvjy7soabMXrfPWARN25PZoriDEiLMxAp50AUW3t35BGQUMg5xK3UrpVTtagIDklxYa+MhiNA==",
+            "version": "0.8.5",
+            "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs3/-/babel-plugin-polyfill-corejs3-0.8.5.tgz",
+            "integrity": "sha512-Q6CdATeAvbScWPNLB8lzSO7fgUVBkQt6zLgNlfyeCr/EQaEQR+bWiBYYPYAFyE528BMjRhL+1QBMOI4jc/c5TA==",
             "dev": true,
             "dependencies": {
-                "@babel/helper-define-polyfill-provider": "^0.4.2",
-                "core-js-compat": "^3.31.0"
+                "@babel/helper-define-polyfill-provider": "^0.4.3",
+                "core-js-compat": "^3.32.2"
             },
             "peerDependencies": {
                 "@babel/core": "^7.4.0 || ^8.0.0-0 <8.0.0"
             }
         },
         "node_modules/babel-plugin-polyfill-regenerator": {
-            "version": "0.5.2",
-            "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-regenerator/-/babel-plugin-polyfill-regenerator-0.5.2.tgz",
-            "integrity": "sha512-tAlOptU0Xj34V1Y2PNTL4Y0FOJMDB6bZmoW39FeCQIhigGLkqu3Fj6uiXpxIf6Ij274ENdYx64y6Au+ZKlb1IA==",
+            "version": "0.5.3",
+            "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-regenerator/-/babel-plugin-polyfill-regenerator-0.5.3.tgz",
+            "integrity": "sha512-8sHeDOmXC8csczMrYEOf0UTNa4yE2SxV5JGeT/LP1n0OYVDUUFPxG9vdk2AlDlIit4t+Kf0xCtpgXPBwnn/9pw==",
             "dev": true,
             "dependencies": {
-                "@babel/helper-define-polyfill-provider": "^0.4.2"
+                "@babel/helper-define-polyfill-provider": "^0.4.3"
             },
             "peerDependencies": {
                 "@babel/core": "^7.4.0 || ^8.0.0-0 <8.0.0"
@@ -5249,9 +5253,9 @@
             }
         },
         "node_modules/browserslist": {
-            "version": "4.21.10",
-            "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.21.10.tgz",
-            "integrity": "sha512-bipEBdZfVH5/pwrvqc+Ub0kUPVfGUhlKxbvfD+z1BDnPEO/X98ruXGA1WP5ASpAFKan7Qr6j736IacbZQuAlKQ==",
+            "version": "4.22.1",
+            "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.22.1.tgz",
+            "integrity": "sha512-FEVc202+2iuClEhZhrWy6ZiAcRLvNMyYcxZ8raemul1DYVOVdFsbqckWLdsixQZCpJlwe77Z3UTalE7jsjnKfQ==",
             "funding": [
                 {
                     "type": "opencollective",
@@ -5267,10 +5271,10 @@
                 }
             ],
             "dependencies": {
-                "caniuse-lite": "^1.0.30001517",
-                "electron-to-chromium": "^1.4.477",
+                "caniuse-lite": "^1.0.30001541",
+                "electron-to-chromium": "^1.4.535",
                 "node-releases": "^2.0.13",
-                "update-browserslist-db": "^1.0.11"
+                "update-browserslist-db": "^1.0.13"
             },
             "bin": {
                 "browserslist": "cli.js"
@@ -5528,9 +5532,9 @@
             }
         },
         "node_modules/caniuse-lite": {
-            "version": "1.0.30001538",
-            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001538.tgz",
-            "integrity": "sha512-HWJnhnID+0YMtGlzcp3T9drmBJUVDchPJ08tpUGFLs9CYlwWPH2uLgpHn8fND5pCgXVtnGS3H4QR9XLMHVNkHw==",
+            "version": "1.0.30001547",
+            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001547.tgz",
+            "integrity": "sha512-W7CrtIModMAxobGhz8iXmDfuJiiKg1WADMO/9x7/CLNin5cpSbuBjooyoIUVB5eyCc36QuTVlkVa1iB2S5+/eA==",
             "funding": [
                 {
                     "type": "opencollective",
@@ -6172,9 +6176,9 @@
             }
         },
         "node_modules/convert-source-map": {
-            "version": "1.9.0",
-            "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.9.0.tgz",
-            "integrity": "sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A==",
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+            "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
             "dev": true
         },
         "node_modules/cookie": {
@@ -6473,9 +6477,9 @@
             }
         },
         "node_modules/core-js": {
-            "version": "3.32.2",
-            "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.32.2.tgz",
-            "integrity": "sha512-pxXSw1mYZPDGvTQqEc5vgIb83jGQKFGYWY76z4a7weZXUolw3G+OvpZqSRcfYOoOVUQJYEPsWeQK8pKEnUtWxQ==",
+            "version": "3.33.0",
+            "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.33.0.tgz",
+            "integrity": "sha512-HoZr92+ZjFEKar5HS6MC776gYslNOKHt75mEBKWKnPeFDpZ6nH5OeF3S6HFT1mUAUZKrzkez05VboaX8myjSuw==",
             "hasInstallScript": true,
             "funding": {
                 "type": "opencollective",
@@ -6483,12 +6487,12 @@
             }
         },
         "node_modules/core-js-compat": {
-            "version": "3.32.2",
-            "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.32.2.tgz",
-            "integrity": "sha512-+GjlguTDINOijtVRUxrQOv3kfu9rl+qPNdX2LTbJ/ZyVTuxK+ksVSAGX1nHstu4hrv1En/uPTtWgq2gI5wt4AQ==",
+            "version": "3.33.0",
+            "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.33.0.tgz",
+            "integrity": "sha512-0w4LcLXsVEuNkIqwjjf9rjCoPhK8uqA4tMRh4Ge26vfLtUutshn+aRJU21I9LCJlh2QQHfisNToLjw1XEJLTWw==",
             "dev": true,
             "dependencies": {
-                "browserslist": "^4.21.10"
+                "browserslist": "^4.22.1"
             },
             "funding": {
                 "type": "opencollective",
@@ -8288,9 +8292,9 @@
             }
         },
         "node_modules/electron-to-chromium": {
-            "version": "1.4.524",
-            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.524.tgz",
-            "integrity": "sha512-iTmhuiGXYo29QoFXwwXbxhAKiDRZQzme6wYVaZNoitg9h1iRaMGu3vNvDyk+gqu5ETK1D6ug9PC5GVS7kSURuw=="
+            "version": "1.4.550",
+            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.550.tgz",
+            "integrity": "sha512-LfcsAzGj18xBYFM5WetwNQdqA03iLDozfCo0SWpu5G9zA5H1G/2GOiHOVnQdOrqaZ8vI8IiSgS3JMUrq930zsw=="
         },
         "node_modules/elliptic": {
             "version": "6.5.4",
@@ -9667,17 +9671,17 @@
             }
         },
         "node_modules/focus-trap": {
-            "version": "7.5.2",
-            "resolved": "https://registry.npmjs.org/focus-trap/-/focus-trap-7.5.2.tgz",
-            "integrity": "sha512-p6vGNNWLDGwJCiEjkSK6oERj/hEyI9ITsSwIUICBoKLlWiTWXJRfQibCwcoi50rTZdbi87qDtUlMCmQwsGSgPw==",
+            "version": "7.5.3",
+            "resolved": "https://registry.npmjs.org/focus-trap/-/focus-trap-7.5.3.tgz",
+            "integrity": "sha512-7UsT/eSJcTPF0aZp73u7hBRTABz26knRRTJfoTGFCQD5mUImLIIOwWWCrtoQdmWa7dykBi6H+Cp5i3S/kvsMeA==",
             "dependencies": {
                 "tabbable": "^6.2.0"
             }
         },
         "node_modules/follow-redirects": {
-            "version": "1.15.2",
-            "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.2.tgz",
-            "integrity": "sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA==",
+            "version": "1.15.3",
+            "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.3.tgz",
+            "integrity": "sha512-1VzOtuEM8pC9SFU1E+8KfTjZyMztRsgEfwQl44z8A25uy13jSzTj6dyK2Df52iV0vgHCfBwLhDWevLn95w5v6Q==",
             "funding": [
                 {
                     "type": "individual",
@@ -10036,9 +10040,9 @@
             }
         },
         "node_modules/fs-monkey": {
-            "version": "1.0.4",
-            "resolved": "https://registry.npmjs.org/fs-monkey/-/fs-monkey-1.0.4.tgz",
-            "integrity": "sha512-INM/fWAxMICjttnD0DX1rBvinKskj5G1w+oy/pnm9u/tSlnBrzFonJMcalKJ30P8RRsPzKcCG7Q8l0jx5Fh9YQ==",
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/fs-monkey/-/fs-monkey-1.0.5.tgz",
+            "integrity": "sha512-8uMbBjrhzW76TYgEV27Y5E//W2f/lTFmx78P2w19FZSxarhI/798APGQyuGCwmkNxgwGRhrLfvWyLBvNtuOmew==",
             "dev": true,
             "optional": true
         },
@@ -10075,7 +10079,8 @@
         "node_modules/function-bind": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-            "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
+            "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
+            "dev": true
         },
         "node_modules/function.prototype.name": {
             "version": "1.1.6",
@@ -10367,12 +10372,9 @@
             }
         },
         "node_modules/has": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
-            "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
-            "dependencies": {
-                "function-bind": "^1.1.1"
-            },
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/has/-/has-1.0.4.tgz",
+            "integrity": "sha512-qdSAmqLF6209RFj4VVItywPMbm3vWylknmB3nvNiUIs72xAimcM8nVYxYr7ncvZq5qzk9MKIZR8ijqD/1QuYjQ==",
             "engines": {
                 "node": ">= 0.4.0"
             }
@@ -12003,22 +12005,22 @@
             }
         },
         "node_modules/launch-editor": {
-            "version": "2.6.0",
-            "resolved": "https://registry.npmjs.org/launch-editor/-/launch-editor-2.6.0.tgz",
-            "integrity": "sha512-JpDCcQnyAAzZZaZ7vEiSqL690w7dAEyLao+KC96zBplnYbJS7TYNjvM3M7y3dGz+v7aIsJk3hllWuc0kWAjyRQ==",
+            "version": "2.6.1",
+            "resolved": "https://registry.npmjs.org/launch-editor/-/launch-editor-2.6.1.tgz",
+            "integrity": "sha512-eB/uXmFVpY4zezmGp5XtU21kwo7GBbKB+EQ+UZeWtGb9yAM5xt/Evk+lYH3eRNAtId+ej4u7TYPFZ07w4s7rRw==",
             "dev": true,
             "dependencies": {
                 "picocolors": "^1.0.0",
-                "shell-quote": "^1.7.3"
+                "shell-quote": "^1.8.1"
             }
         },
         "node_modules/launch-editor-middleware": {
-            "version": "2.6.0",
-            "resolved": "https://registry.npmjs.org/launch-editor-middleware/-/launch-editor-middleware-2.6.0.tgz",
-            "integrity": "sha512-K2yxgljj5TdCeRN1lBtO3/J26+AIDDDw+04y6VAiZbWcTdBwsYN6RrZBnW5DN/QiSIdKNjKdATLUUluWWFYTIA==",
+            "version": "2.6.1",
+            "resolved": "https://registry.npmjs.org/launch-editor-middleware/-/launch-editor-middleware-2.6.1.tgz",
+            "integrity": "sha512-Fg/xYhf7ARmRp40n18wIfJyuAMEjXo67Yull7uF7d0OJ3qA4EYJISt1XfPPn69IIJ5jKgQwzcg6DqHYo95LL/g==",
             "dev": true,
             "dependencies": {
-                "launch-editor": "^2.6.0"
+                "launch-editor": "^2.6.1"
             }
         },
         "node_modules/launch-editor/node_modules/picocolors": {
@@ -12272,9 +12274,9 @@
             }
         },
         "node_modules/magic-string": {
-            "version": "0.30.3",
-            "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.3.tgz",
-            "integrity": "sha512-B7xGbll2fG/VjP+SWg4sX3JynwIU0mjoTc6MPpKNuIvftk6u6vqhDnk1R80b8C2GBR6ywqy+1DcKBrevBg+bmw==",
+            "version": "0.30.4",
+            "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.4.tgz",
+            "integrity": "sha512-Q/TKtsC5BPm0kGqgBIF9oXAs/xEf2vRKiIB4wCRQTJOQIByZ1d+NnUOotvJOvNpi5RNIgVOMC3pOuaP1ZTDlVg==",
             "dependencies": {
                 "@jridgewell/sourcemap-codec": "^1.4.15"
             },
@@ -13650,6 +13652,11 @@
             "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
             "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw=="
         },
+        "node_modules/papaparse": {
+            "version": "5.4.1",
+            "resolved": "https://registry.npmjs.org/papaparse/-/papaparse-5.4.1.tgz",
+            "integrity": "sha512-HipMsgJkZu8br23pW15uvo6sib6wne/4woLZPlFf3rpDyMe9ywEXUsuD7+6K9PRkJlVT51j/sCOYDKGGS3ZJrw=="
+        },
         "node_modules/parallel-transform": {
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/parallel-transform/-/parallel-transform-1.2.0.tgz",
@@ -14894,9 +14901,9 @@
             "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ=="
         },
         "node_modules/purgecss/node_modules/postcss": {
-            "version": "8.4.30",
-            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.30.tgz",
-            "integrity": "sha512-7ZEao1g4kd68l97aWG/etQKPKq07us0ieSZ2TnFDk11i0ZfDW2AwKHYU8qv4MZKqN2fdBfg+7q0ES06UA73C1g==",
+            "version": "8.4.31",
+            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",
+            "integrity": "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==",
             "funding": [
                 {
                     "type": "opencollective",
@@ -14995,6 +15002,33 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/ramp-storylines": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/ramp-storylines/-/ramp-storylines-3.0.2.tgz",
+            "integrity": "sha512-BaZubmkcLDj9vLAz9aGJbVtC2HstfmftqLhvroYVrIrCdg+VW9RueOxDzOejexGloZpkb2ocPqxunx9bd8ab4g==",
+            "dependencies": {
+                "@tailwindcss/typography": "^0.4.0",
+                "@types/highcharts": "^7.0.0",
+                "core-js": "^3.6.5",
+                "highcharts": "^9.3.2",
+                "highcharts-vue": "^1.4.3",
+                "intersection-observer": "^0.12.2",
+                "jszip": "^3.10.1",
+                "markdown-it": "^12.0.6",
+                "nouislider": "^15.5.0",
+                "vue": "^3.3.4",
+                "vue-class-component": "^8.0.0-rc.1",
+                "vue-fullscreen": "^3.1.1",
+                "vue-i18n": "^9.2.2",
+                "vue-papa-parse": "^3.1.0",
+                "vue-property-decorator": "^10.0.0-rc.2",
+                "vue-router": "^4.2.4",
+                "vue-tippy": "^6.3.1",
+                "vue3-carousel": "^0.3.1",
+                "vue3-scrollama": "^0.2.2",
+                "vue3-spinners": "^1.2.2"
             }
         },
         "node_modules/randombytes": {
@@ -15417,9 +15451,9 @@
             "integrity": "sha512-LwZrotdHOo12nQuZlHEmtuXdqGoOD0OhaxopaNFxWzInpEgaLWoVuAMbTzixuosCx2nEG58ngzW3vxdWoxIgdg=="
         },
         "node_modules/resolve": {
-            "version": "1.22.6",
-            "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.6.tgz",
-            "integrity": "sha512-njhxM7mV12JfufShqGy3Rz8j11RPdLy4xi15UurGJeoHLfJpVXKdh3ueuOqbYUcDZnffr6X739JBo5LzyahEsw==",
+            "version": "1.22.8",
+            "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.8.tgz",
+            "integrity": "sha512-oKWePCxqpd6FlLvGV1VU0x7bkPmmCNolxzjMf4NczoDnQcIWrAF+cPtZn5i6n+RfD2d9i0tzpKnG6Yk168yIyw==",
             "dependencies": {
                 "is-core-module": "^2.13.0",
                 "path-parse": "^1.0.7",
@@ -15649,9 +15683,9 @@
             "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
         },
         "node_modules/sass": {
-            "version": "1.67.0",
-            "resolved": "https://registry.npmjs.org/sass/-/sass-1.67.0.tgz",
-            "integrity": "sha512-SVrO9ZeX/QQyEGtuZYCVxoeAL5vGlYjJ9p4i4HFuekWl8y/LtJ7tJc10Z+ck1c8xOuoBm2MYzcLfTAffD0pl/A==",
+            "version": "1.69.2",
+            "resolved": "https://registry.npmjs.org/sass/-/sass-1.69.2.tgz",
+            "integrity": "sha512-48lDtG/9OuSQZ9oNmJMUXI2QdCakAWrAGjpX/Fy6j4Og8dEAyE598x5GqCqnHkwV7+I5w8DJpqjm581q5HNh3w==",
             "dev": true,
             "dependencies": {
                 "chokidar": ">=3.0.0 <4.0.0",
@@ -15760,6 +15794,22 @@
                 "type": "opencollective",
                 "url": "https://opencollective.com/webpack"
             }
+        },
+        "node_modules/screenfull": {
+            "version": "5.2.0",
+            "resolved": "https://registry.npmjs.org/screenfull/-/screenfull-5.2.0.tgz",
+            "integrity": "sha512-9BakfsO2aUQN2K9Fdbj87RJIEZ82Q9IGim7FqM5OsebfoFC6ZHXgDq/KvniuLTPdeM8wY2o6Dj3WQ7KeQCj3cA==",
+            "engines": {
+                "node": ">=0.10.0"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/scrollama": {
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/scrollama/-/scrollama-3.2.0.tgz",
+            "integrity": "sha512-PIPwB1kYBnbw/ezvPBJa5dCN5qEwokfpAkI3BmpZWAwcVID4nDf1qH6WV16A2fQaJmsKx0un5S/zhxN+PQeKDQ=="
         },
         "node_modules/section-matter": {
             "version": "1.0.0",
@@ -16514,9 +16564,9 @@
             }
         },
         "node_modules/spdx-license-ids": {
-            "version": "3.0.15",
-            "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.15.tgz",
-            "integrity": "sha512-lpT8hSQp9jAKp9mhtBU4Xjon8LPGBvLIuBiSVhMEtmLecTh2mO0tlqrAMp47tBXzMr13NJMQ2lf7RpQGLJ3HsQ==",
+            "version": "3.0.16",
+            "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.16.tgz",
+            "integrity": "sha512-eWN+LnM3GR6gPu35WxNgbGl8rmY1AEmoMDvL/QD6zYmPWgywxWqJWNdLGT+ke8dKNWrcYgYjPpG5gbTfghP8rw==",
             "dev": true
         },
         "node_modules/spdy": {
@@ -18158,6 +18208,11 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
+        "node_modules/undici-types": {
+            "version": "5.25.3",
+            "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.25.3.tgz",
+            "integrity": "sha512-Ga1jfYwRn7+cP9v8auvEXN1rX3sWqlayd4HP7OKk4mZWylEmu3KzXDUGrQUN6Ol7qo1gPvB2e5gX6udnyEPgdA=="
+        },
         "node_modules/unicode-canonical-property-names-ecmascript": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/unicode-canonical-property-names-ecmascript/-/unicode-canonical-property-names-ecmascript-2.0.0.tgz",
@@ -18327,9 +18382,9 @@
             }
         },
         "node_modules/update-browserslist-db": {
-            "version": "1.0.11",
-            "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.0.11.tgz",
-            "integrity": "sha512-dCwEFf0/oT85M1fHBg4F0jtLwJrutGoHSQXCh7u4o2t1drG+c0a9Flnqww6XUKSfQMPpJBRjU8d4RXB09qtvaA==",
+            "version": "1.0.13",
+            "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.0.13.tgz",
+            "integrity": "sha512-xebP81SNcPuNpPP3uzeW1NYXxI3rxyJzF3pD6sH4jE7o/IX+WtSpwnVU+qIsDPyk0d3hmFQ7mjqc6AtV604hbg==",
             "funding": [
                 {
                     "type": "opencollective",
@@ -18631,9 +18686,9 @@
             }
         },
         "node_modules/vue-eslint-parser": {
-            "version": "9.3.1",
-            "resolved": "https://registry.npmjs.org/vue-eslint-parser/-/vue-eslint-parser-9.3.1.tgz",
-            "integrity": "sha512-Clr85iD2XFZ3lJ52/ppmUDG/spxQu6+MAeHXjjyI4I1NUYZ9xmenQp4N0oaHJhrA8OOxltCVxMRfANGa70vU0g==",
+            "version": "9.3.2",
+            "resolved": "https://registry.npmjs.org/vue-eslint-parser/-/vue-eslint-parser-9.3.2.tgz",
+            "integrity": "sha512-q7tWyCVaV9f8iQyIA5Mkj/S6AoJ9KBN8IeUSf3XEmBrOtxOZnfTg5s4KClbZBCK3GtnT/+RyCLZyDHuZwTuBjg==",
             "dev": true,
             "dependencies": {
                 "debug": "^4.3.4",
@@ -18737,6 +18792,17 @@
                 "vue": ">=3.2.0"
             }
         },
+        "node_modules/vue-fullscreen": {
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/vue-fullscreen/-/vue-fullscreen-3.1.1.tgz",
+            "integrity": "sha512-I59sIO0O22116gwVPo1qM2cNf5binEC5vTswIm8qJsqgatGfFquIJANpoVggSUS2EgUF0Xg4tHliT1ITcwQw8Q==",
+            "dependencies": {
+                "screenfull": "^5.1.0"
+            },
+            "peerDependencies": {
+                "vue": "^3.0.0"
+            }
+        },
         "node_modules/vue-hot-reload-api": {
             "version": "2.3.4",
             "resolved": "https://registry.npmjs.org/vue-hot-reload-api/-/vue-hot-reload-api-2.3.4.tgz",
@@ -18744,12 +18810,12 @@
             "dev": true
         },
         "node_modules/vue-i18n": {
-            "version": "9.4.1",
-            "resolved": "https://registry.npmjs.org/vue-i18n/-/vue-i18n-9.4.1.tgz",
-            "integrity": "sha512-vnQyYE9LBuNOqPpETIcCaGnAyLEqfeIvDcyZ9T+WBCWFTqWw1J8FuF1jfeDwpHBi5JKgAwgXyq1mt8jp/x/GPA==",
+            "version": "9.5.0",
+            "resolved": "https://registry.npmjs.org/vue-i18n/-/vue-i18n-9.5.0.tgz",
+            "integrity": "sha512-NiI3Ph1qMstNf7uhYh8trQBOBFLxeJgcOxBq51pCcZ28Vs18Y7BDS58r8HGDKCYgXdLUYqPDXdKatIF4bvBVZg==",
             "dependencies": {
-                "@intlify/core-base": "9.4.1",
-                "@intlify/shared": "9.4.1",
+                "@intlify/core-base": "9.5.0",
+                "@intlify/shared": "9.5.0",
                 "@vue/devtools-api": "^6.5.0"
             },
             "engines": {
@@ -18919,6 +18985,17 @@
             "resolved": "https://registry.npmjs.org/vue-m-message/-/vue-m-message-4.0.2.tgz",
             "integrity": "sha512-6rTKtIzj2vXyyY6YIcSHDmJNz4R1HuxATgr8gf0c+DjcknwCkmfBggKNDIgshnCyqgL70TWsVrgcqQzl4xsYfQ=="
         },
+        "node_modules/vue-papa-parse": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/vue-papa-parse/-/vue-papa-parse-3.1.0.tgz",
+            "integrity": "sha512-5YdF3Dtf49EGfaz3+IgIpUw9yYuvV3HekZkob6jrK/Ffz1aCrWjevtcQByKxrNtK7RAL39B0ca93bogKuiQQKg==",
+            "dependencies": {
+                "papaparse": "^5.3.0"
+            },
+            "peerDependencies": {
+                "vue": "^2.6.0 || >=3.0.0"
+            }
+        },
         "node_modules/vue-property-decorator": {
             "version": "10.0.0-rc.3",
             "resolved": "https://registry.npmjs.org/vue-property-decorator/-/vue-property-decorator-10.0.0-rc.3.tgz",
@@ -18929,9 +19006,9 @@
             }
         },
         "node_modules/vue-router": {
-            "version": "4.2.4",
-            "resolved": "https://registry.npmjs.org/vue-router/-/vue-router-4.2.4.tgz",
-            "integrity": "sha512-9PISkmaCO02OzPVOMq2w82ilty6+xJmQrarYZDkjZBfl4RvYAlt4PKnEX21oW4KTtWfa9OuO/b3qk1Od3AEdCQ==",
+            "version": "4.2.5",
+            "resolved": "https://registry.npmjs.org/vue-router/-/vue-router-4.2.5.tgz",
+            "integrity": "sha512-DIUpKcyg4+PTQKfFPX88UWhlagBEBEfJ5A8XDXRJLUnZOvcpMF8o/dnL90vpVkGaPbjvXazV/rC1qBKrZlFugw==",
             "dependencies": {
                 "@vue/devtools-api": "^6.5.0"
             },
@@ -18999,6 +19076,25 @@
             },
             "peerDependencies": {
                 "vue": "^3.2.0"
+            }
+        },
+        "node_modules/vue3-carousel": {
+            "version": "0.3.1",
+            "resolved": "https://registry.npmjs.org/vue3-carousel/-/vue3-carousel-0.3.1.tgz",
+            "integrity": "sha512-86vUkNPBzL2PVuR9w6hUsI90ccFjLp+K8cSFpRTISf+SjUQY3fMHc5CFF5MUL62v1xYYm27zEBmQupO9VQx9Kw==",
+            "peerDependencies": {
+                "vue": "^3.2.0"
+            }
+        },
+        "node_modules/vue3-scrollama": {
+            "version": "0.2.2",
+            "resolved": "https://registry.npmjs.org/vue3-scrollama/-/vue3-scrollama-0.2.2.tgz",
+            "integrity": "sha512-RGjqv7J1H3Ro/o/90K/k2L5rdowE+hG6HlTxA7Pc/oZDazLc7jzGqhh+2fmzmQ//LqMtRJYrAdjXsyXsrc58bA==",
+            "dependencies": {
+                "scrollama": "^3.2.0"
+            },
+            "peerDependencies": {
+                "vue": "^3.2.13"
             }
         },
         "node_modules/vue3-spinners": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "storylines-editor",
-    "version": "0.1.0",
+    "version": "1.0.0",
     "private": true,
     "scripts": {
         "serve": "vue-cli-service serve",
@@ -21,6 +21,7 @@
         "jszip": "^3.10.1",
         "markdown-it": "^12.0.6",
         "nouislider": "^15.5.0",
+        "ramp-storylines": "^3.0.2",
         "uuid": "^9.0.0",
         "vue": "^3.3.4",
         "vue-class-component": "^8.0.0-rc.1",

--- a/src/components/editor/helpers/chart-preview.vue
+++ b/src/components/editor/helpers/chart-preview.vue
@@ -28,14 +28,14 @@
                 </svg>
             </button>
             <!-- chart component -->
-            <dqv-chart
+            <storylines-chart
                 class="w-full h-full"
                 :config="chartConfig"
                 :key="chartIdx"
                 :configFileStructure="configFileStructure"
                 @loaded="loadChart"
                 v-if="!loading"
-            ></dqv-chart>
+            ></storylines-chart>
         </div>
         <!-- chart description and edit  -->
         <div class="flex mt-4 items-center">
@@ -60,7 +60,7 @@
 </template>
 
 <script lang="ts">
-import { Options, Prop, Vue } from 'vue-property-decorator';
+import { Prop, Vue } from 'vue-property-decorator';
 import {
     ChartConfig,
     ConfigFileStructure,
@@ -70,12 +70,6 @@ import {
     PieSeriesData
 } from '@/definitions';
 
-@Options({
-    components: {
-        // TODO: fix when storylines plugin updated to Vue 3
-        // 'dqv-chart': ChartV
-    }
-})
 export default class ChartPreviewV extends Vue {
     @Prop() chart!: ChartConfig;
     @Prop() configFileStructure!: ConfigFileStructure;

--- a/src/components/editor/preview.vue
+++ b/src/components/editor/preview.vue
@@ -14,15 +14,16 @@
                 </div>
             </header>
 
-            <!-- <introduction :config="config.introSlide" :configFileStructure="configFileStructure"></introduction> -->
+            <storylines-intro :config="config.introSlide" :configFileStructure="configFileStructure" />
 
             <div class="w-full mx-auto pb-10" id="story">
-                <!-- <StoryContentV
+                <storylines-content
                     :config="config"
                     :configFileStructure="configFileStructure"
                     :lang="lang"
+                    :plugin="true"
                     @step="updateActiveIndex"
-                /> -->
+                />
             </div>
 
             <footer class="p-8 pt-2 text-right text-sm">

--- a/src/main.ts
+++ b/src/main.ts
@@ -30,7 +30,8 @@ import HighchartsVue from 'highcharts-vue';
 import Message from 'vue-m-message';
 import 'vue-m-message/dist/style.css';
 
-// TODO: import storylines viewer as plugin once a Vue 3 version is published
+import StorylinesViewer from 'ramp-storylines';
+import 'ramp-storylines/dist/storylines-viewer.css';
 
 const app = createApp(App);
 
@@ -42,6 +43,7 @@ app.use(router)
     })
     .use(HighchartsVue)
     .use(Message)
+    .use(StorylinesViewer)
     .use(VueMarkdownEditor)
     .use(vfm);
 

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -16,16 +16,16 @@ const routes = [
     },
     {
         path: '/:lang/editor-metadata',
-        name: 'metadataNew',
+        name: 'metadataExisting',
         component: MetadataEditorV,
-        props: { editExisting: false },
+        props: { editExisting: true },
         meta: { title: 'editor.window.title' }
     },
     {
         path: '/:lang/editor-metadata',
-        name: 'metadataExisting',
+        name: 'metadataNew',
         component: MetadataEditorV,
-        props: { editExisting: true },
+        props: { editExisting: false },
         meta: { title: 'editor.window.title' }
     },
     {

--- a/src/shims-vue.d.ts
+++ b/src/shims-vue.d.ts
@@ -6,6 +6,7 @@ declare module '*.vue' {
 declare module '@kangc/v-md-editor';
 declare module '@kangc/v-md-editor/lib/lang/en-US';
 declare module '@kangc/v-md-editor/lib/theme/github.js';
+declare module 'ramp-storylines';
 declare module 'vue-m-message';
 declare module 'highcharts-vue';
 declare module 'vue-tippy';


### PR DESCRIPTION
Adds the new `ramp-storylines` Vue 3 plugin from: https://www.npmjs.com/package/ramp-storylines. This will enable support for the preview Storylines and preview charts functionality. 

The code changes made to turn Storylines into a Vue 3 plugin is contained on my local repo and will make a PR to the main repo once the Vue 3 PR for Storylines is merged.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/yileifeng/storylines-editor/9)
<!-- Reviewable:end -->
