### PR TITLE
Fix slide selection on config language swap

### DIFF
--- a/src/components/editor/dynamic-editor.vue
+++ b/src/components/editor/dynamic-editor.vue
@@ -250,12 +250,14 @@ export default class DynamicEditorV extends Vue {
     }
 
     saveChanges(): void {
-        if (
-            this.$refs.slide !== undefined &&
-            typeof (this.$refs.slide as ImageEditorV | ChartEditorV).saveChanges === 'function'
-        ) {
-            (this.$refs.slide as ImageEditorV | ChartEditorV).saveChanges();
-        }
+        this.$nextTick(() => {
+            if (
+                this.$refs.slide !== undefined &&
+                typeof (this.$refs.slide as ImageEditorV | ChartEditorV).saveChanges === 'function'
+            ) {
+                (this.$refs.slide as ImageEditorV | ChartEditorV).saveChanges();
+            }
+        });
     }
 }
 </script>

--- a/src/components/editor/editor.vue
+++ b/src/components/editor/editor.vue
@@ -209,7 +209,9 @@ export default class EditorV extends Vue {
     selectSlide(index: number): void {
         // save changes to current slide before changing slides
         if (this.$refs.slide !== undefined) {
-            (this.$refs.slide as SlideEditorV).saveChanges();
+            this.$nextTick(() => {
+                (this.$refs.slide as SlideEditorV).saveChanges();
+            });
         }
 
         // Quickly swap to loading page, and then swap to new slide. Allows Vue to re-draw page correctly.
@@ -253,7 +255,9 @@ export default class EditorV extends Vue {
     saveChanges(): void {
         // save current slide final changes before generating config file
         if (this.$refs.slide !== undefined) {
-            (this.$refs.slide as SlideEditorV).saveChanges();
+            this.$nextTick(() => {
+                (this.$refs.slide as SlideEditorV).saveChanges();
+            });
         }
 
         // emit save changes event

--- a/src/components/editor/metadata-editor.vue
+++ b/src/components/editor/metadata-editor.vue
@@ -725,8 +725,12 @@ export default class MetadataEditorV extends Vue {
             return;
         }
         this.loadConfig(this.configs[this.configLang]);
+
         if (this.loadEditor) {
-            (this.$refs.mainEditor as EditorV).selectSlide(-1);
+            (this.$refs.mainEditor as EditorV).updateSlides(this.slides);
+            this.$nextTick(() => {
+                (this.$refs.mainEditor as EditorV).selectSlide(-1);
+            });
         }
     }
 

--- a/src/components/editor/slide-editor.vue
+++ b/src/components/editor/slide-editor.vue
@@ -397,12 +397,14 @@ export default class SlideEditorV extends Vue {
     }
 
     saveChanges(): void {
-        if (
-            this.$refs.editor !== undefined &&
-            typeof (this.$refs.editor as ImageEditorV | ChartEditorV).saveChanges === 'function'
-        ) {
-            (this.$refs.editor as ImageEditorV | ChartEditorV).saveChanges();
-        }
+        this.$nextTick(() => {
+            if (
+                this.$refs.editor !== undefined &&
+                typeof (this.$refs.editor as ImageEditorV | ChartEditorV).saveChanges === 'function'
+            ) {
+                (this.$refs.editor as ImageEditorV | ChartEditorV).saveChanges();
+            }
+        });
     }
 
     selectSlide(index: number): void {


### PR DESCRIPTION
Properly updated slide content upon switching languages. Also added nextTick to ensure DOM is updated before accessing refs to prevent console error.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/yileifeng/storylines-editor/11)
<!-- Reviewable:end -->
